### PR TITLE
feat: 회의 내용에 따라 API response 수정(#13)

### DIFF
--- a/src/main/java/reviewme/be/comment/response/CommentResponse.java
+++ b/src/main/java/reviewme/be/comment/response/CommentResponse.java
@@ -33,7 +33,7 @@ public class CommentResponse {
     private LocalDateTime createdAt;;
 
     @Schema(description = "이모지 정보")
-    private List<Emoji> emojiInfos;
+    private List<Emoji> emojis;
 
     @Schema(description = "내가 선택한 이모지", example = "1")
     private long myEmojiId;
@@ -47,7 +47,7 @@ public class CommentResponse {
                 .commenterName(comment.getWriter().getName())
                 .commenterProfileUrl(comment.getWriter().getProfileUrl())
                 .createdAt(comment.getCreatedAt())
-                .emojiInfos(emojiInfos)
+                .emojis(emojiInfos)
                 .myEmojiId(myEmojiId)
                 .build();
     }

--- a/src/main/java/reviewme/be/feedback/controller/FeedbackController.java
+++ b/src/main/java/reviewme/be/feedback/controller/FeedbackController.java
@@ -125,6 +125,8 @@ public class FeedbackController {
                         .feedbackId(1L)
                         .content("프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다.")
                         .writerId(1L)
+                        .writerName("aken-you")
+                        .writerProfileUrl("https://avatars.githubusercontent.com/u/96980857?v=4")
                         .createdAt(LocalDateTime.now())
                         .emojiInfos(sampleEmojis)
                         .myEmojiId(1L)

--- a/src/main/java/reviewme/be/feedback/response/CommentOfFeedbackResponse.java
+++ b/src/main/java/reviewme/be/feedback/response/CommentOfFeedbackResponse.java
@@ -25,6 +25,12 @@ public class CommentOfFeedbackResponse {
     @Schema(description = "댓글 작성자 ID", example = "1")
     private long writerId;
 
+    @Schema(description = "댓글 작성자 이름", example = "aken-you")
+    private String writerName;
+
+    @Schema(description = "댓글 작성자 프로필 사진", example = "https://avatars.githubusercontent.com/u/96980857?v=4")
+    private String writerProfileUrl;
+
     @Schema(description = "댓글 작성 시간", example = "2023-12-15")
     private LocalDateTime createdAt;
 

--- a/src/main/java/reviewme/be/feedback/response/FeedbackResponse.java
+++ b/src/main/java/reviewme/be/feedback/response/FeedbackResponse.java
@@ -23,6 +23,12 @@ public class FeedbackResponse {
     @Schema(description = "피드백을 남긴 사용자 ID", example = "1")
     private long writerId;
 
+    @Schema(description = "피드백을 남긴 사용자 이름", example = "aken-you")
+    private String writerName;
+
+    @Schema(description = "피드백을 남긴 사용자 프로필 사진", example = "https://avatars.githubusercontent.com/u/96980857?v=4")
+    private String writerProfileUrl;
+
     @Schema(description = "피드백 라벨 ID", example = "1")
     private long labelId;
 
@@ -47,6 +53,8 @@ public class FeedbackResponse {
                 .id(feedback.getId())
                 .content(feedback.getContent())
                 .writerId(feedback.getWriter().getId())
+                .writerName(feedback.getWriter().getName())
+                .writerProfileUrl(feedback.getWriter().getProfileUrl())
                 .labelId(feedback.getLabel().getId())
                 .createdAt(feedback.getCreatedAt())
                 .countOfReplies(feedback.getChildCnt())

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -121,6 +121,8 @@ public class QuestionController {
                         .questionId(1L)
                         .content("프로젝트에서 react-query를 사용하셨는데 사용한 이유가 궁금합니다.")
                         .writerId(1L)
+                        .writerName("aken-you")
+                        .writerProfileUrl("https://avatars.githubusercontent.com/u/96980857?v=4")
                         .createdAt(LocalDateTime.now())
                         .emojiInfos(sampleEmojis)
                         .myEmojiId(1L)

--- a/src/main/java/reviewme/be/question/response/CommentOfQuestionResponse.java
+++ b/src/main/java/reviewme/be/question/response/CommentOfQuestionResponse.java
@@ -25,6 +25,12 @@ public class CommentOfQuestionResponse {
     @Schema(description = "댓글 작성자 ID", example = "1")
     private long writerId;
 
+    @Schema(description = "댓글 작성자 이름", example = "aken-you")
+    private String writerName;
+
+    @Schema(description = "댓글 작성자 프로필 사진", example = "https://avatars.githubusercontent.com/u/96980857?v=4")
+    private String writerProfileUrl;
+
     @Schema(description = "댓글 작성 시간", example = "2023-12-15")
     private LocalDateTime createdAt;
 

--- a/src/main/java/reviewme/be/question/response/QuestionResponse.java
+++ b/src/main/java/reviewme/be/question/response/QuestionResponse.java
@@ -23,6 +23,12 @@ public class QuestionResponse {
     @Schema(description = "질문자 ID", example = "1")
     private long writerId;
 
+    @Schema(description = "질문자 이름", example = "aken-you")
+    private String writerName;
+
+    @Schema(description = "질문자 프로필 사진", example = "https://avatars.githubusercontent.com/u/96980857?v=4")
+    private String writerProfileUrl;
+
     @Schema(description = "예상 질문 라벨 ID", example = "1")
     private long labelId;
 
@@ -50,6 +56,8 @@ public class QuestionResponse {
                 .id(question.getId())
                 .content(question.getContent())
                 .writerId(question.getWriter().getId())
+                .writerName(question.getWriter().getName())
+                .writerProfileUrl(question.getWriter().getProfileUrl())
                 .labelId(question.getLabel().getId())
                 .createdAt(question.getCreatedAt())
                 .countOfReplies(question.getChildCnt())
@@ -66,6 +74,8 @@ public class QuestionResponse {
                 .id(question.getId())
                 .content(question.getContent())
                 .writerId(question.getWriter().getId())
+                .writerName(question.getWriter().getName())
+                .writerProfileUrl(question.getWriter().getProfileUrl())
                 .labelId(question.getLabel().getId())
                 .createdAt(question.getCreatedAt())
                 .countOfReplies(question.getChildCnt())

--- a/src/main/java/reviewme/be/resume/controller/ResumeController.java
+++ b/src/main/java/reviewme/be/resume/controller/ResumeController.java
@@ -143,7 +143,7 @@ public class ResumeController {
         ResumeResponse sampleUpdatedResumeResponse = ResumeResponse.builder()
                 .id(1L)
                 .title("네이버 신입 대비") // TODO: updateResumeRequest Title()
-                .writer("aken-you")
+                .writerName("aken-you")
                 .createdAt(LocalDateTime.now())
                 .scopeId(1L)    // TODO: updateResumeRequest ScopeId()
                 .occupationId(1)

--- a/src/main/java/reviewme/be/resume/response/ResumeResponse.java
+++ b/src/main/java/reviewme/be/resume/response/ResumeResponse.java
@@ -18,8 +18,14 @@ public class ResumeResponse {
     @Schema(description = "이력서 제목", example = "네이버 신입 개발자 준비")
     private String title;
 
+    @Schema(description = "이력서 작성자 ID", example = "1")
+    private long writerId;
+
     @Schema(description = "이력서 작성자 이름", example = "aken-you")
-    private String writer;
+    private String writerName;
+
+    @Schema(description = "이력서 작성자 프로필 사진", example = "https://avatars.githubusercontent.com/u/96980857?v=4")
+    private String writerProfileUrl;
 
     @Schema(description = "이력서 작성 시간", example = "2023-11-22")
     private LocalDateTime createdAt;
@@ -37,7 +43,9 @@ public class ResumeResponse {
         return ResumeResponse.builder()
                 .id(resume.getId())
                 .title(resume.getTitle())
-                .writer(resume.getUser().getName())
+                .writerId(resume.getUser().getId())
+                .writerName(resume.getUser().getName())
+                .writerProfileUrl(resume.getUser().getProfileUrl())
                 .createdAt(resume.getCreatedAt())
                 .scopeId(resume.getScope().getId())
                 .occupationId(resume.getOccupation().getId())


### PR DESCRIPTION
## 개요
- 백엔드(luke)가 API 문서 작성 -> 회의를 통해서 response 일부 수정 요청 

## 작업 사항
- 사용자 이름, 프로필 url이 필요한 페이지에서 개인 정보 조회 API 통해 조회하는 것이 아닌 response에 담아서 반환하도록 함

## 이슈 번호
- #13 