### PR TITLE
[BE] feat: 친구 요청 수락 API(#37)

### DIFF
--- a/src/main/java/reviewme/be/friend/controller/FriendController.java
+++ b/src/main/java/reviewme/be/friend/controller/FriendController.java
@@ -60,7 +60,7 @@ public class FriendController {
     })
     public ResponseEntity<CustomResponse> acceptFriend(@Validated @RequestBody AcceptFriendRequest acceptFriendRequest) {
 
-        // TODO: 친구 요청 목록에 있는지 검증
+        friendService.acceptFriend(userId, acceptFriendRequest.getUserId());
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/reviewme/be/friend/controller/FriendExceptionHandler.java
+++ b/src/main/java/reviewme/be/friend/controller/FriendExceptionHandler.java
@@ -6,12 +6,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import reviewme.be.custom.CustomErrorResponse;
 import reviewme.be.friend.exception.AlreadyFriendRelationException;
 import reviewme.be.friend.exception.AlreadyFriendRequestedException;
+import reviewme.be.friend.exception.NotOnTheFriendRequestException;
 
 @RestControllerAdvice
 public class FriendExceptionHandler {
 
     @ExceptionHandler(AlreadyFriendRequestedException.class)
-    public ResponseEntity<CustomErrorResponse> invalidCode(AlreadyFriendRequestedException ex) {
+    public ResponseEntity<CustomErrorResponse> alreadyFriendRequested(AlreadyFriendRequestedException ex) {
 
         return ResponseEntity
                 .badRequest()
@@ -22,7 +23,18 @@ public class FriendExceptionHandler {
     }
 
     @ExceptionHandler(AlreadyFriendRelationException.class)
-    public ResponseEntity<CustomErrorResponse> invalidCode(AlreadyFriendRelationException ex) {
+    public ResponseEntity<CustomErrorResponse> alreadyFriendRelation(AlreadyFriendRelationException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "Bad Request",
+                        400,
+                        ex.getMessage()));
+    }
+
+    @ExceptionHandler(NotOnTheFriendRequestException.class)
+    public ResponseEntity<CustomErrorResponse> notOnTheFriendRequest(NotOnTheFriendRequestException ex) {
 
         return ResponseEntity
                 .badRequest()

--- a/src/main/java/reviewme/be/friend/entity/Friend.java
+++ b/src/main/java/reviewme/be/friend/entity/Friend.java
@@ -26,12 +26,26 @@ public class Friend {
 
     private Boolean accepted;
 
-    public static Friend ofCreated(User followerUser, User followingUser) {
+    public static Friend newRequest(User followerUser, User followingUser) {
 
         return Friend.builder()
                 .followerUser(followerUser)
                 .followingUser(followingUser)
                 .accepted(false)
                 .build();
+    }
+
+    public static Friend newRelation(User followerUser, User followingUser) {
+
+        return Friend.builder()
+                .followerUser(followerUser)
+                .followingUser(followingUser)
+                .accepted(true)
+                .build();
+    }
+
+    public void acceptRequest() {
+
+        this.accepted = true;
     }
 }

--- a/src/main/java/reviewme/be/friend/exception/NotOnTheFriendRequestException.java
+++ b/src/main/java/reviewme/be/friend/exception/NotOnTheFriendRequestException.java
@@ -1,0 +1,9 @@
+package reviewme.be.friend.exception;
+
+public class NotOnTheFriendRequestException extends RuntimeException {
+
+    public NotOnTheFriendRequestException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/reviewme/be/friend/repository/FriendRepository.java
+++ b/src/main/java/reviewme/be/friend/repository/FriendRepository.java
@@ -11,6 +11,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     Friend save(Friend createdFriendRequest);
 
+    Friend findByFollowerUserIdAndFollowingUserIdAndAcceptedIsFalse(long followerUserId, long followingUserId);
+
     List<Friend> findByFollowingUserIdAndAcceptedIsTrue(long followingUserId);
 
     long countByFollowingUserIdAndAcceptedIsTrue(long followingUserId);

--- a/src/main/java/reviewme/be/friend/service/FriendService.java
+++ b/src/main/java/reviewme/be/friend/service/FriendService.java
@@ -18,21 +18,36 @@ public class FriendService {
     private final UserService userService;
 
     @Transactional
-    public void requestFriend(long userId, long friendId) {
+    public void requestFriend(long userId, long followingUserId) {
 
         User followerUser = userService.getUserById(userId);
-        User followingUser = userService.getUserById(friendId);
+        User followingUser = userService.getUserById(followingUserId);
 
-        if (friendRepository.isRequested(userId, friendId)) {
+        if (friendRepository.isRequested(userId, followingUserId)) {
             throw new AlreadyFriendRequestedException("이미 친구 요청을 보냈습니다.");
         }
 
-        if (friendRepository.isFriend(userId, friendId)) {
+        if (friendRepository.isFriend(userId, followingUserId)) {
             throw new AlreadyFriendRelationException("이미 친구 관계인 회원입니다.");
         }
 
         friendRepository.save(
                 Friend.ofCreated(followerUser, followingUser));
+    }
+
+    @Transactional
+    public void acceptFriend(long userId, long followingUserId) {
+
+        User followerUser = userService.getUserById(userId);
+        User followingUser = userService.getUserById(followingUserId);
+
+        if (friendRepository.isFriend(userId, followingUserId)) {
+            throw new AlreadyFriendRelationException("이미 친구 관계인 회원입니다.");
+        }
+
+        if (!friendRepository.isRequested(userId, followingUserId)) {
+            throw new RuntimeException("친구 요청 목록에 없습니다.");
+        }
     }
 
     public boolean isFriend(long userId, long friendId) {

--- a/src/main/java/reviewme/be/friend/service/FriendService.java
+++ b/src/main/java/reviewme/be/friend/service/FriendService.java
@@ -32,13 +32,13 @@ public class FriendService {
         }
 
         friendRepository.save(
-                Friend.ofCreated(followerUser, followingUser));
+                Friend.newRequest(followerUser, followingUser));
     }
 
     @Transactional
     public void acceptFriend(long userId, long followingUserId) {
 
-        User followerUser = userService.getUserById(userId);
+        User user = userService.getUserById(userId);
         User followingUser = userService.getUserById(followingUserId);
 
         if (friendRepository.isFriend(userId, followingUserId)) {
@@ -48,6 +48,13 @@ public class FriendService {
         if (!friendRepository.isRequested(userId, followingUserId)) {
             throw new RuntimeException("친구 요청 목록에 없습니다.");
         }
+
+        Friend friend = friendRepository.findByFollowerUserIdAndFollowingUserIdAndAcceptedIsFalse(userId, followingUserId);
+
+        friend.acceptRequest();
+
+        friendRepository.save(
+                Friend.newRelation(followingUser, user));
     }
 
     public boolean isFriend(long userId, long friendId) {


### PR DESCRIPTION
## 개요
- 다른 사용자가 친구 요청을 보내면 요청받은 사용자는 친구 요청 수락을 할 수 있다.

## 작업 사항
- 예외 처리
   - 이미 친구 관계인 회원인 경우
   - 친구 요청 목록에 없는 경우

- 친구 요청 수락을 하면 following과 follower를 바꿔 새로운 레코드를 만듭니다.
- 친구 요청 수락, 친구 삭제 시 작은 cost가 추가로 들것입니다.
- 하지만, 친구 목록 조회, 이력서 조회 등 다른 API에서 테이블 join에 대한 비용을 줄일 수 있으므로 이러한 방식을 선택했습니다.

## 이슈 번호
- #37 