### PR TITLE
feat: resource server로부터 받는 데이터 출처가 기존 서버와 다름에 따라 cors config 추가(#48)

### DIFF
--- a/src/main/java/reviewme/be/config/CorsConfig.java
+++ b/src/main/java/reviewme/be/config/CorsConfig.java
@@ -1,0 +1,20 @@
+package reviewme.be.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+
+        registry.addMapping("/**")
+                .allowedOrigins("http://13.209.230.48")
+                .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.DELETE.name(), HttpMethod.OPTIONS.name())
+                .allowCredentials(true)
+                .allowedHeaders("*");
+    }
+}


### PR DESCRIPTION
## 개요
- resource server로부터 받아오는 데이터의 출처가 다름에 따라 브라우저 cors 정책에 걸림

## 작업 사항
- cors config 추가

## 이슈 번호
- #48 