### PR TITLE
[BE] feat: 예상 질문 관련 API (조회, 이모지 수정 제외) (#67)

### DIFF
--- a/src/main/java/reviewme/be/config/WebConfig.java
+++ b/src/main/java/reviewme/be/config/WebConfig.java
@@ -27,7 +27,8 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludePathPatterns("/login/oauth",
                         "/swagger-ui/**",
                         "/api-docs/**",
-                        "//user/refresh");
+                        "/login/oauth",
+                        "/user/refresh");
 ////
 //        registry.addInterceptor(loginOrNotInterceptor)
 //                .order(3)

--- a/src/main/java/reviewme/be/config/interceptor/AuthInterceptor.java
+++ b/src/main/java/reviewme/be/config/interceptor/AuthInterceptor.java
@@ -43,12 +43,12 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         String jwt = request.getHeader("Authorization").split(" ")[1];
 
-        if (jwtService.validateJwtIsExpired(jwt)) {
-            throw new NoValidBearerFormatException("유효 기간이 만료된 토큰입니다.");
-        }
-
         if (jwtService.validateJwtIsManipulated(jwt)) {
             throw new ManipulatedTokenException("조작된 토큰입니다.");
+        }
+
+        if (jwtService.validateJwtIsExpired(jwt)) {
+            throw new NoValidBearerFormatException("유효 기간이 만료된 토큰입니다.");
         }
 
         UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);

--- a/src/main/java/reviewme/be/config/interceptor/AuthInterceptor.java
+++ b/src/main/java/reviewme/be/config/interceptor/AuthInterceptor.java
@@ -43,13 +43,13 @@ public class AuthInterceptor implements HandlerInterceptor {
 
         String jwt = request.getHeader("Authorization").split(" ")[1];
 
-//        if (jwtService.validateJwtIsExpired(jwt)) {
-//            throw new NoValidBearerFormatException("유효 기간이 만료된 토큰입니다.");
-//        }
-//
-//        if (jwtService.validateJwtIsManipulated(jwt)) {
-//            throw new ManipulatedTokenException("조작된 토큰입니다.");
-//        }
+        if (jwtService.validateJwtIsExpired(jwt)) {
+            throw new NoValidBearerFormatException("유효 기간이 만료된 토큰입니다.");
+        }
+
+        if (jwtService.validateJwtIsManipulated(jwt)) {
+            throw new ManipulatedTokenException("조작된 토큰입니다.");
+        }
 
         UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);
         User user = userService.getUserById(loggedInUser.getId());

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
@@ -5,8 +5,13 @@ import reviewme.be.feedback.entity.Feedback;
 
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
 
     List<Feedback> findByResumeIdAndResumePage(long resumeId, int resumePage);
+
+    Optional<Feedback> findByIdAndDeletedAtIsNull(long feedbackId);
+
+    Optional<Feedback> findByIdAndResumeIdAndDeletedAtIsNull(long feedbackId, long resumeId);
 }

--- a/src/main/java/reviewme/be/feedback/service/FeedbackService.java
+++ b/src/main/java/reviewme/be/feedback/service/FeedbackService.java
@@ -83,13 +83,19 @@ public class FeedbackService {
         resume.validateUser(user);
 
         // 피드백 존재 여부 확인
-        Feedback feedback = findById(feedbackId);
+        Feedback feedback = validateFeedbackByResumeId(feedbackId, resumeId);
         feedback.updateChecked(request.isChecked());
     }
 
     private Feedback findById(long feedbackId) {
 
-        return feedbackRepository.findById(feedbackId)
+        return feedbackRepository.findByIdAndDeletedAtIsNull(feedbackId)
+            .orElseThrow(() -> new NonExistFeedbackException("존재하지 않는 피드백입니다."));
+    }
+
+    private Feedback validateFeedbackByResumeId(long feedbackId, long resumeId) {
+
+        return feedbackRepository.findByIdAndResumeIdAndDeletedAtIsNull(feedbackId, resumeId)
             .orElseThrow(() -> new NonExistFeedbackException("존재하지 않는 피드백입니다."));
     }
 }

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -180,9 +180,13 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 북마크 상태 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 북마크 상태 수정 실패")
     })
-    public ResponseEntity<CustomResponse<Void>> updateQuestionBookmark(@Validated @RequestBody UpdateQuestionBookmarkRequest updateQuestionBookmarkRequest, @PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse<Void>> updateQuestionBookmark(
+            @Validated @RequestBody UpdateQuestionBookmarkRequest updateQuestionBookmarkRequest,
+            @PathVariable long resumeId,
+            @PathVariable long questionId,
+            @RequestAttribute("user") User user) {
 
-        // TODO: 본인의 resume인지 검증, 맞다면 request 상태로 수정
+        questionService.updateQuestionBookmark(updateQuestionBookmarkRequest, resumeId, questionId, user);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -19,11 +19,14 @@ import reviewme.be.question.repository.QuestionRepository;
 import reviewme.be.question.dto.request.*;
 import reviewme.be.question.dto.response.*;
 import reviewme.be.custom.CustomResponse;
+import reviewme.be.question.service.QuestionService;
+import reviewme.be.user.entity.User;
 import reviewme.be.util.dto.response.LabelPageResponse;
 import reviewme.be.util.dto.response.LabelResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Tag(name = "question", description = "예상 질문(question) API")
 @RequestMapping("/resume/{resumeId}/question")
@@ -31,6 +34,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class QuestionController {
 
+    private final QuestionService questionService;
     private final QuestionRepository questionRepository;
     private final QuestionEmojiRepository questionEmojiRepository;
 
@@ -183,17 +187,13 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 라벨 목록 조회 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 라벨 목록 조회 실패")
     })
-    public ResponseEntity<CustomResponse<LabelPageResponse>> showLabelsOfQuestions(@PathVariable long resumeId) {
+    public ResponseEntity<CustomResponse<LabelPageResponse>> showQuestionLabels(
+            @PathVariable long resumeId) {
 
-        List<LabelResponse> sampleLabels = List.of(
-                LabelResponse.builder()
-                        .id(1L)
-                        .label("react-query")
-                        .build(),
-                LabelResponse.builder()
-                        .id(2L)
-                        .label("typescript")
-                        .build());
+        List<LabelResponse> questionLabelsResponse = questionService.findQuestionLabels(resumeId)
+                .stream()
+                .map(LabelResponse::fromLabel)
+                .collect(Collectors.toList());
 
         return ResponseEntity
                 .ok()
@@ -202,7 +202,7 @@ public class QuestionController {
                         200,
                         "예상 질문 라벨 목록 조회에 성공했습니다.",
                         LabelPageResponse.builder()
-                                .labels(sampleLabels)
+                                .labels(questionLabelsResponse)
                                 .build()
                 ));
     }

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -35,8 +35,6 @@ import java.util.stream.Collectors;
 public class QuestionController {
 
     private final QuestionService questionService;
-    private final QuestionRepository questionRepository;
-    private final QuestionEmojiRepository questionEmojiRepository;
 
     @Operation(summary = "예상 질문 추가", description = "예상 질문을 추가합니다.")
     @PostMapping
@@ -44,27 +42,19 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 추가 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 추가 실패")
     })
-    public ResponseEntity<CustomResponse<PostedQuestionResponse>> postQuestions(@Validated @RequestBody PostQuestionRequest postQuestionRequest, @PathVariable long resumeId) {
+    public ResponseEntity<CustomResponse<Void>> postQuestions(
+            @Validated @RequestBody PostQuestionRequest postQuestionRequest,
+            @PathVariable long resumeId,
+            @RequestAttribute("user") User user) {
 
-        PostedQuestionResponse sampleResponse = PostedQuestionResponse.builder()
-                .resumeId(1L)
-                .commenterId(1L)
-                .commenterName("aken-you")
-                .commenterProfileUrl("https://avatars.githubusercontent.com/u/96980857?v=4")
-                .content(postQuestionRequest.getContent())
-                .labelContent("react-query")
-                .resumePage(1)
-                .questionId(1L)
-                .createdAt(LocalDateTime.now())
-                .build();
+        questionService.saveQuestion(postQuestionRequest, resumeId, user);
 
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
                         "success",
                         200,
-                        "예상 질문 추가에 성공했습니다.",
-                        sampleResponse
+                        "예상 질문 추가에 성공했습니다."
                 ));
     }
 

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -134,7 +134,13 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateQuestionContent(@Validated @RequestBody UpdateQuestionContentRequest updateQuestionContentRequest, @PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse> updateQuestionContent(
+            @Validated @RequestBody UpdateQuestionContentRequest updateQuestionContentRequest,
+            @PathVariable long resumeId,
+            @PathVariable long questionId,
+            @RequestAttribute("user") User user) {
+
+        questionService.updateQuestionContent(updateQuestionContentRequest, resumeId, questionId, user);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -112,7 +112,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 삭제 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 삭제 실패")
     })
-    public ResponseEntity<CustomResponse> deleteQuestions(
+    public ResponseEntity<CustomResponse<Void>> deleteQuestions(
             @PathVariable long resumeId,
             @PathVariable long questionId,
             @RequestAttribute("user") User user) {
@@ -134,7 +134,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateQuestionContent(
+    public ResponseEntity<CustomResponse<Void>> updateQuestionContent(
             @Validated @RequestBody UpdateQuestionContentRequest updateQuestionContentRequest,
             @PathVariable long resumeId,
             @PathVariable long questionId,
@@ -157,10 +157,13 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 체크 상태 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 체크 상태 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateQuestionCheck(@Validated @RequestBody UpdateQuestionCheckRequest updateQuestionCheckRequest, @PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse<Void>> updateQuestionCheck(
+            @Validated @RequestBody UpdateQuestionCheckRequest updateQuestionCheckRequest,
+            @PathVariable long resumeId,
+            @PathVariable long questionId,
+            @RequestAttribute("user") User user) {
 
-        // TODO: 본인의 resume인지 검증, 맞다면 request 상태로 수정
-        // TODO: question이 댓글이 아닌 question인 경우에만 체크 상태 수정 가능
+        questionService.updateQuestionCheck(updateQuestionCheckRequest, resumeId, questionId, user);
 
         return ResponseEntity
                 .ok()
@@ -177,7 +180,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 북마크 상태 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 북마크 상태 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateQuestionBookmark(@Validated @RequestBody UpdateQuestionBookmarkRequest updateQuestionBookmarkRequest, @PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse<Void>> updateQuestionBookmark(@Validated @RequestBody UpdateQuestionBookmarkRequest updateQuestionBookmarkRequest, @PathVariable long resumeId, @PathVariable long questionId) {
 
         // TODO: 본인의 resume인지 검증, 맞다면 request 상태로 수정
 
@@ -222,7 +225,7 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 이모지 상태 수정 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 이모지 상태 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateQuestionEmoji(@Validated @RequestBody UpdateQuestionEmojiRequest updateQuestionEmojiRequest, @PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse<Void>> updateQuestionEmoji(@Validated @RequestBody UpdateQuestionEmojiRequest updateQuestionEmojiRequest, @PathVariable long resumeId, @PathVariable long questionId) {
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -112,9 +112,12 @@ public class QuestionController {
             @ApiResponse(responseCode = "200", description = "예상 질문 삭제 성공"),
             @ApiResponse(responseCode = "400", description = "예상 질문 삭제 실패")
     })
-    public ResponseEntity<CustomResponse> deleteQuestions(@PathVariable long resumeId, @PathVariable long questionId) {
+    public ResponseEntity<CustomResponse> deleteQuestions(
+            @PathVariable long resumeId,
+            @PathVariable long questionId,
+            @RequestAttribute("user") User user) {
 
-        // TODO: 본인이 작성한 question만 삭제 가능
+        questionService.deleteQuestion(resumeId, questionId, user);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/reviewme/be/question/controller/QuestionExceptionHandler.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionExceptionHandler.java
@@ -1,0 +1,15 @@
+package reviewme.be.question.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import reviewme.be.custom.CustomErrorResponse;
+import reviewme.be.resume.exception.BadFileExtensionException;
+import reviewme.be.resume.exception.NonExistResumeException;
+import reviewme.be.resume.exception.NotYourResumeException;
+
+@RestControllerAdvice
+public class QuestionExceptionHandler {
+
+
+}

--- a/src/main/java/reviewme/be/question/controller/QuestionExceptionHandler.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionExceptionHandler.java
@@ -4,12 +4,19 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import reviewme.be.custom.CustomErrorResponse;
-import reviewme.be.resume.exception.BadFileExtensionException;
-import reviewme.be.resume.exception.NonExistResumeException;
-import reviewme.be.resume.exception.NotYourResumeException;
+import reviewme.be.question.exception.NonExistQuestionException;
 
 @RestControllerAdvice
 public class QuestionExceptionHandler {
 
+    @ExceptionHandler(NonExistQuestionException.class)
+    public ResponseEntity<CustomErrorResponse> nonExistQuestionException(NonExistQuestionException ex) {
 
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "Bad Request",
+                        400,
+                        ex.getMessage()));
+    }
 }

--- a/src/main/java/reviewme/be/question/dto/request/PostQuestionRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/PostQuestionRequest.java
@@ -20,10 +20,13 @@ public class PostQuestionRequest {
     @Schema(description = "댓글을 추가할 예상 질문 ID", example = "1", required = false)
     private Long questionId;
 
+    @Schema(description = "라벨 ID", example = "1", required = false)
+    private Long labelId;
+
     @Schema(description = "라벨 내용", example = "react-query", required = false)
     private String labelContent;
 
     @Schema(description = "이력서 페이지", example = "1")
     @NotNull(message = "이력서의 몇 페이지에 질문을 하는 지는 필수 입력 값입니다.")
-    private Long resumePage;
+    private int resumePage;
 }

--- a/src/main/java/reviewme/be/question/dto/request/UpdateQuestionBookmarkRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/UpdateQuestionBookmarkRequest.java
@@ -15,5 +15,5 @@ public class UpdateQuestionBookmarkRequest {
 
     @Schema(description = "예상 질문 북마크 상태 수정 요청", example = "true")
     @NotNull(message = "북마크 상태는 필수 입력 값입니다.")
-    private Boolean bookmarked;
+    private boolean bookmarked;
 }

--- a/src/main/java/reviewme/be/question/dto/request/UpdateQuestionCheckRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/UpdateQuestionCheckRequest.java
@@ -14,5 +14,5 @@ public class UpdateQuestionCheckRequest {
 
     @Schema(description = "예상 질문 체크 상태 수정 요청", example = "true")
     @NotNull(message = "체크 상태는 필수 입력 값입니다.")
-    private Boolean checked;
+    private boolean checked;
 }

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -48,6 +48,11 @@ public class Question {
         this.commenter.validateSameUser(user);
     }
 
+    public void updateContent(String content) {
+
+        this.content = content;
+    }
+
     public void softDelete() {
 
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -42,4 +42,14 @@ public class Question {
     private Long childCnt;
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
+
+    public void validateUser(User user) {
+
+        this.commenter.validateSameUser(user);
+    }
+
+    public void softDelete() {
+
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -43,9 +43,41 @@ public class Question {
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
 
+    public static Question createQuestion(User commenter, Resume resume, Label label, String content, Integer resumePage) {
+
+        return Question.builder()
+            .commenter(commenter)
+            .resume(resume)
+            .label(label)
+            .content(content)
+            .resumePage(resumePage)
+            .bookmarked(false)
+            .checked(false)
+            .childCnt(0L)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+
+    public static Question createChildQuestion(User commenter, Resume resume, Question parentQuestion, String content, Integer resumePage) {
+
+        return Question.builder()
+            .commenter(commenter)
+            .resume(resume)
+            .parentQuestion(parentQuestion)
+            .content(content)
+            .resumePage(resumePage)
+            .createdAt(LocalDateTime.now())
+            .build();
+    }
+
     public void validateUser(User user) {
 
         this.commenter.validateSameUser(user);
+    }
+
+    public void plusChildCnt() {
+
+        this.childCnt++;
     }
 
     public void updateContent(String content) {

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -58,6 +58,11 @@ public class Question {
         this.checked = checked;
     }
 
+    public void updateBookmarked(boolean bookmarked) {
+
+        this.bookmarked = bookmarked;
+    }
+
     public void softDelete() {
 
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -53,6 +53,11 @@ public class Question {
         this.content = content;
     }
 
+    public void updateChecked(boolean checked) {
+
+        this.checked = checked;
+    }
+
     public void softDelete() {
 
         this.deletedAt = LocalDateTime.now();

--- a/src/main/java/reviewme/be/question/exception/NonExistQuestionException.java
+++ b/src/main/java/reviewme/be/question/exception/NonExistQuestionException.java
@@ -1,0 +1,9 @@
+package reviewme.be.question.exception;
+
+public class NonExistQuestionException extends RuntimeException {
+
+    public NonExistQuestionException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/reviewme/be/question/repository/QuestionRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionRepository.java
@@ -11,4 +11,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     List<Question> findByResumeIdAndResumePage(long resumeId, int resumePage);
 
     Optional<Question> findByIdAndDeletedAtIsNull(long questionId);
+
+    Optional<Question> findByIdAndResumeIdAndDeletedAtIsNull(long questionId, long resumeId);
 }

--- a/src/main/java/reviewme/be/question/repository/QuestionRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionRepository.java
@@ -13,4 +13,6 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Optional<Question> findByIdAndDeletedAtIsNull(long questionId);
 
     Optional<Question> findByIdAndResumeIdAndDeletedAtIsNull(long questionId, long resumeId);
+
+    Optional<Question> findByIdAndResumeIdAndResumePageAndDeletedAtIsNull(long questionId, long resumeId, int resumePage);
 }

--- a/src/main/java/reviewme/be/question/repository/QuestionRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionRepository.java
@@ -4,8 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import reviewme.be.question.entity.Question;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     List<Question> findByResumeIdAndResumePage(long resumeId, int resumePage);
+
+    Optional<Question> findByIdAndDeletedAtIsNull(long questionId);
 }

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -3,6 +3,7 @@ package reviewme.be.question.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reviewme.be.question.dto.request.UpdateQuestionContentRequest;
 import reviewme.be.question.entity.Question;
 import reviewme.be.question.exception.NonExistQuestionException;
 import reviewme.be.question.repository.QuestionRepository;
@@ -32,6 +33,19 @@ public class QuestionService {
         question.validateUser(user);
 
         question.softDelete();
+    }
+
+    @Transactional
+    public void updateQuestionContent(UpdateQuestionContentRequest request, long resumeId, long questionId, User user) {
+
+        // 이력서 존재 여부 확인
+        resumeService.findById(resumeId);
+
+        // 질문 존재 여부 및 수정 권한 확인
+        Question question = findById(questionId);
+        question.validateUser(user);
+
+        question.updateContent(request.getContent());
     }
 
     @Transactional

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -3,10 +3,13 @@ package reviewme.be.question.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reviewme.be.feedback.entity.Feedback;
+import reviewme.be.question.dto.request.UpdateQuestionCheckRequest;
 import reviewme.be.question.dto.request.UpdateQuestionContentRequest;
 import reviewme.be.question.entity.Question;
 import reviewme.be.question.exception.NonExistQuestionException;
 import reviewme.be.question.repository.QuestionRepository;
+import reviewme.be.resume.entity.Resume;
 import reviewme.be.resume.service.ResumeService;
 import reviewme.be.user.entity.User;
 import reviewme.be.util.entity.Label;
@@ -46,6 +49,19 @@ public class QuestionService {
         question.validateUser(user);
 
         question.updateContent(request.getContent());
+    }
+
+    @Transactional
+    public void updateQuestionCheck(UpdateQuestionCheckRequest request, long resumeId, long questionId, User user) {
+
+        // 이력서 존재 여부 및 체크 수정 권한 확인
+        Resume resume = resumeService.findById(resumeId);
+        resume.validateUser(user);
+
+        // 예상 질문 존재 여부 확인
+        Question question = findById(questionId);
+
+        question.updateChecked(request.isChecked());
     }
 
     @Transactional

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -1,0 +1,22 @@
+package reviewme.be.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reviewme.be.question.repository.QuestionRepository;
+import reviewme.be.util.entity.Label;
+import reviewme.be.util.repository.LabelRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final LabelRepository labelRepository;
+
+    public List<Label> findQuestionLabels(long resumeId) {
+
+        return labelRepository.findByResumeId(resumeId);
+    }
+}

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -3,6 +3,7 @@ package reviewme.be.question.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import reviewme.be.question.repository.QuestionRepository;
+import reviewme.be.resume.service.ResumeService;
 import reviewme.be.util.entity.Label;
 import reviewme.be.util.repository.LabelRepository;
 
@@ -13,9 +14,13 @@ import java.util.List;
 public class QuestionService {
 
     private final QuestionRepository questionRepository;
+    private final ResumeService resumeService;
     private final LabelRepository labelRepository;
 
     public List<Label> findQuestionLabels(long resumeId) {
+
+        // 이력서 존재 여부 확인
+        resumeService.findById(resumeId);
 
         return labelRepository.findByResumeId(resumeId);
     }

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -2,8 +2,12 @@ package reviewme.be.question.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reviewme.be.question.entity.Question;
+import reviewme.be.question.exception.NonExistQuestionException;
 import reviewme.be.question.repository.QuestionRepository;
 import reviewme.be.resume.service.ResumeService;
+import reviewme.be.user.entity.User;
 import reviewme.be.util.entity.Label;
 import reviewme.be.util.repository.LabelRepository;
 
@@ -17,11 +21,31 @@ public class QuestionService {
     private final ResumeService resumeService;
     private final LabelRepository labelRepository;
 
+    @Transactional
+    public void deleteQuestion(long resumeId, long questionId, User user) {
+
+        // 이력서 존재 여부 확인
+        resumeService.findById(resumeId);
+
+        // 질문 존재 여부 및 삭제 권한 확인
+        Question question = findById(questionId);
+        question.validateUser(user);
+
+        question.softDelete();
+    }
+
+    @Transactional
     public List<Label> findQuestionLabels(long resumeId) {
 
         // 이력서 존재 여부 확인
         resumeService.findById(resumeId);
 
         return labelRepository.findByResumeId(resumeId);
+    }
+
+    private Question findById(long questionId) {
+
+        return questionRepository.findByIdAndDeletedAtIsNull(questionId)
+                .orElseThrow(() -> new NonExistQuestionException("존재하지 않는 질문입니다."));
     }
 }

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import reviewme.be.feedback.entity.Feedback;
+import reviewme.be.question.dto.request.UpdateQuestionBookmarkRequest;
 import reviewme.be.question.dto.request.UpdateQuestionCheckRequest;
 import reviewme.be.question.dto.request.UpdateQuestionContentRequest;
 import reviewme.be.question.entity.Question;
@@ -62,6 +63,19 @@ public class QuestionService {
         Question question = validateQuestionByResumeId(questionId, resumeId);
 
         question.updateChecked(request.isChecked());
+    }
+
+    @Transactional
+    public void updateQuestionBookmark(UpdateQuestionBookmarkRequest request, long resumeId, long questionId, User user) {
+
+        // 이력서 존재 여부 및 체크 수정 권한 확인
+        Resume resume = resumeService.findById(resumeId);
+        resume.validateUser(user);
+
+        // 해당 이력서에 예상 질문 존재 여부 확인
+        Question question = validateQuestionByResumeId(questionId, resumeId);
+
+        question.updateBookmarked(request.isBookmarked());
     }
 
     @Transactional

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -58,8 +58,8 @@ public class QuestionService {
         Resume resume = resumeService.findById(resumeId);
         resume.validateUser(user);
 
-        // 예상 질문 존재 여부 확인
-        Question question = findById(questionId);
+        // 해당 이력서에 예상 질문 존재 여부 확인
+        Question question = validateQuestionByResumeId(questionId, resumeId);
 
         question.updateChecked(request.isChecked());
     }
@@ -76,6 +76,12 @@ public class QuestionService {
     private Question findById(long questionId) {
 
         return questionRepository.findByIdAndDeletedAtIsNull(questionId)
+                .orElseThrow(() -> new NonExistQuestionException("존재하지 않는 질문입니다."));
+    }
+
+    private Question validateQuestionByResumeId(long questionId, long resumeId) {
+
+        return questionRepository.findByIdAndResumeIdAndDeletedAtIsNull(questionId, resumeId)
                 .orElseThrow(() -> new NonExistQuestionException("존재하지 않는 질문입니다."));
     }
 }

--- a/src/main/java/reviewme/be/user/controller/UserController.java
+++ b/src/main/java/reviewme/be/user/controller/UserController.java
@@ -42,16 +42,16 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "GitHub으로 로그인", description = "GitHub 계정을 통해 사용자가 로그인합니다.")
-    @GetMapping("/login/oauth")
+    @PostMapping("/login/oauth")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
             @ApiResponse(responseCode = "400", description = "로그인 실패")
     })
     public ResponseEntity<CustomResponse<LoginUserResponse>> loginWithGitHub(
-            @RequestParam String code,
+            @RequestBody OAuthCodeRequest request,
             HttpServletResponse response) {
 
-        UserGitHubToken userGitHubToken = oauthLoginService.getUserGitHubToken(code);
+        UserGitHubToken userGitHubToken = oauthLoginService.getUserGitHubToken(request.getCode());
 
         String jwt = createJwtByAccessToken(userGitHubToken.getAccessToken());
 

--- a/src/main/java/reviewme/be/user/service/JWTService.java
+++ b/src/main/java/reviewme/be/user/service/JWTService.java
@@ -3,6 +3,7 @@ package reviewme.be.user.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import reviewme.be.user.dto.response.UserProfileResponse;
@@ -13,6 +14,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedHashMap;
 
+@Slf4j
 @Service
 public class JWTService {
 
@@ -36,12 +38,12 @@ public class JWTService {
 
         try {
             Jws<Claims> claimsJws = Jwts.parser()
-                    .setSigningKey(secret.getBytes())
+                    .setSigningKey(secret)
                     .parseClaimsJws(jwt);
 
             return claimsJws.getBody().getExpiration().before(new Date());
         } catch (JwtException e) {
-            System.out.println(e.getMessage());
+            log.info("JWT exception: {}", e);
             return true;
         }
     }

--- a/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import reviewme.be.custom.CustomErrorResponse;
-import reviewme.be.util.exception.NonExistFeedbackLabelException;
+import reviewme.be.util.exception.NonExistLabelException;
 import reviewme.be.util.exception.NonExistOccupationException;
 import reviewme.be.util.exception.NonExistScopeException;
 import reviewme.be.util.exception.NotYoursException;
@@ -70,8 +70,8 @@ public class GlobalExceptionHandler {
     /**
      * util exception handler
      */
-    @ExceptionHandler(NonExistFeedbackLabelException.class)
-    public ResponseEntity<CustomErrorResponse> nonExistFeedbackLabel(NonExistFeedbackLabelException ex) {
+    @ExceptionHandler(NonExistLabelException.class)
+    public ResponseEntity<CustomErrorResponse> nonExistFeedbackLabel(NonExistLabelException ex) {
 
         return ResponseEntity
                 .badRequest()

--- a/src/main/java/reviewme/be/util/entity/Label.java
+++ b/src/main/java/reviewme/be/util/entity/Label.java
@@ -21,4 +21,12 @@ public class Label {
     private Resume resume;
 
     private String content;
+
+    public static Label ofCreated(Resume resume, String content) {
+
+        return Label.builder()
+            .resume(resume)
+            .content(content)
+            .build();
+    }
 }

--- a/src/main/java/reviewme/be/util/exception/NonExistFeedbackLabelException.java
+++ b/src/main/java/reviewme/be/util/exception/NonExistFeedbackLabelException.java
@@ -1,9 +1,0 @@
-package reviewme.be.util.exception;
-
-public class NonExistFeedbackLabelException extends RuntimeException {
-
-    public NonExistFeedbackLabelException(String message) {
-
-        super(message);
-    }
-}

--- a/src/main/java/reviewme/be/util/exception/NonExistLabelException.java
+++ b/src/main/java/reviewme/be/util/exception/NonExistLabelException.java
@@ -1,0 +1,9 @@
+package reviewme.be.util.exception;
+
+public class NonExistLabelException extends RuntimeException {
+
+    public NonExistLabelException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/reviewme/be/util/repository/LabelRepository.java
+++ b/src/main/java/reviewme/be/util/repository/LabelRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface LabelRepository extends JpaRepository<Label, Integer> {
 
     List<Label> findByResumeIsNull();
+
+    List<Label> findByResumeId(long resumeId);
 }

--- a/src/main/java/reviewme/be/util/repository/LabelRepository.java
+++ b/src/main/java/reviewme/be/util/repository/LabelRepository.java
@@ -4,10 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import reviewme.be.util.entity.Label;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LabelRepository extends JpaRepository<Label, Integer> {
 
     List<Label> findByResumeIsNull();
 
     List<Label> findByResumeId(long resumeId);
+
+    Optional<Label> findById(long id);
 }

--- a/src/main/java/reviewme/be/util/service/UtilService.java
+++ b/src/main/java/reviewme/be/util/service/UtilService.java
@@ -5,8 +5,10 @@ import org.springframework.stereotype.Service;
 import reviewme.be.util.entity.Label;
 import reviewme.be.util.entity.Occupation;
 import reviewme.be.util.entity.Scope;
+import reviewme.be.util.exception.NonExistLabelException;
 import reviewme.be.util.exception.NonExistOccupationException;
 import reviewme.be.util.exception.NonExistScopeException;
+import reviewme.be.util.repository.LabelRepository;
 import reviewme.be.util.vo.FeedbackLabelsVO;
 import reviewme.be.util.vo.OccupationsVO;
 import reviewme.be.util.vo.ScopesVO;
@@ -20,13 +22,14 @@ public class UtilService {
     private final FeedbackLabelsVO feedbackLabelsVO;
     private final OccupationsVO occupationsVO;
     private final ScopesVO scopesVO;
+    private final LabelRepository labelRepository;
 
     public Label findFeedbackLabelById(long id) {
 
         Map<Long, Label> feedbackLabels = feedbackLabelsVO.getFeedbackLabels();
 
         if (!feedbackLabels.containsKey(id)) {
-            throw new NonExistOccupationException("[ERROR] 존재하지 않는 라벨입니다.");
+            throw new NonExistLabelException("[ERROR] 존재하지 않는 라벨입니다.");
         }
 
         return feedbackLabels.get(id);
@@ -54,4 +57,9 @@ public class UtilService {
         return scopes.get(id);
     }
 
+    public Label findById(long id) {
+
+        return labelRepository.findById(id)
+                .orElseThrow(() -> new NonExistLabelException("[ERROR] 존재하지 않는 라벨입니다."));
+    }
 }


### PR DESCRIPTION
## 개요
- 사용자는 예상 질문 추가, 수정, 삭제를 할 수 있다.

## 작업 사항
- 검증 로직 수정 -> 피드백에도 적용해야함.
- 생성 시 예상 질문과 그에 대한 댓글 구분(회의 후 로직이 수정될 수 있음)

## 이슈 번호
- #67 