### PR TITLE
[BE] fix: 이력서 목록 조회 로직 수정 및 내 이력서 목록 API 생성

### DIFF
--- a/src/main/java/reviewme/be/config/WebConfig.java
+++ b/src/main/java/reviewme/be/config/WebConfig.java
@@ -1,7 +1,10 @@
 package reviewme.be.config;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import reviewme.be.config.interceptor.AuthInterceptor;
@@ -28,5 +31,14 @@ public class WebConfig implements WebMvcConfigurer {
                         "/swagger-ui/**",
                         "/api-docs/**",
                         "/user/refresh");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
+        // 페이징 요청 시 최대 페이지 사이즈 설정
+        PageableHandlerMethodArgumentResolver pageableResolver = new PageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(30);
+        resolvers.add(pageableResolver);
     }
 }

--- a/src/main/java/reviewme/be/feedback/dto/response/FeedbackResponse.java
+++ b/src/main/java/reviewme/be/feedback/dto/response/FeedbackResponse.java
@@ -39,10 +39,9 @@ public class FeedbackResponse {
     private LocalDateTime createdAt;
 
     @Schema(description = "댓글 개수", example = "10")
-    private long countOfReplies;
+    private long countOfComments;
 
     @Schema(description = "체크 여부", example = "true")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean checked;
 
     @Schema(description = "이모지 정보")
@@ -51,7 +50,7 @@ public class FeedbackResponse {
     @Schema(description = "내가 선택한 이모지", example = "1")
     private Integer myEmojiId;
 
-    public static FeedbackResponse fromFeedbackOfOwnResume(FeedbackInfo feedback,
+    public static FeedbackResponse fromFeedbackOfResume(FeedbackInfo feedback,
         List<EmojiCount> emojis, Integer myEmojiId) {
 
         return FeedbackResponse.builder()
@@ -62,25 +61,8 @@ public class FeedbackResponse {
             .commenterProfileUrl(feedback.getCommenterProfileUrl())
             .labelContent(feedback.getLabelContent())
             .createdAt(feedback.getCreatedAt())
-            .countOfReplies(feedback.getCountOfReplies())
+            .countOfComments(feedback.getCountOfReplies())
             .checked(feedback.isChecked())
-            .emojis(emojis)
-            .myEmojiId(myEmojiId)
-            .build();
-    }
-
-    public static FeedbackResponse fromFeedbackOfOthersResume(FeedbackInfo feedback,
-        List<EmojiCount> emojis, Integer myEmojiId) {
-
-        return FeedbackResponse.builder()
-            .id(feedback.getId())
-            .content(feedback.getContent())
-            .commenterId(feedback.getCommenterId())
-            .commenterName(feedback.getCommenterName())
-            .commenterProfileUrl(feedback.getCommenterProfileUrl())
-            .labelContent(feedback.getLabelContent())
-            .createdAt(feedback.getCreatedAt())
-            .countOfReplies(feedback.getCountOfReplies())
             .emojis(emojis)
             .myEmojiId(myEmojiId)
             .build();

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
@@ -1,24 +1,12 @@
 package reviewme.be.feedback.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import reviewme.be.feedback.entity.FeedbackEmoji;
-
-import javax.persistence.Tuple;
-import java.util.List;
 
 public interface FeedbackEmojiRepository extends JpaRepository<FeedbackEmoji, Long>, FeedbackEmojiRepositoryCustom {
 
-    List<FeedbackEmoji> findByFeedbackId(long feedbackId);
-
-    @Query(value = "SELECT emoji.id AS id, COUNT(emoji.id) AS count " +
-        "FROM FeedbackEmoji feedbackEmoji " +
-        "JOIN feedbackEmoji.emoji emoji " +
-        "WHERE feedbackEmoji.feedback.id = :feedbackId " +
-        "GROUP BY emoji.id")
-    List<Tuple> countByFeedbackIdGroupByEmojiId(long feedbackId);
-
-    FeedbackEmoji findByFeedbackIdAndUserId(long feedbackId, long userId);
+    Optional<FeedbackEmoji> findByFeedbackIdAndUserId(long feedbackId, long userId);
 
     void deleteAllByFeedbackId(long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepositoryCustom.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepositoryCustom.java
@@ -2,11 +2,8 @@ package reviewme.be.feedback.repository;
 
 import java.util.List;
 import reviewme.be.util.dto.EmojiCount;
-import reviewme.be.util.dto.MyEmoji;
 
 public interface FeedbackEmojiRepositoryCustom {
 
     List<EmojiCount> findEmojiCountByFeedbackIds(List<Long> feedbackIds);
-
-    List<MyEmoji> findMyEmojiIdsByFeedbackIdIn(long userId, List<Long> feedbackIds);
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepositoryImpl.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepositoryImpl.java
@@ -10,9 +10,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import reviewme.be.util.dto.EmojiCount;
-import reviewme.be.util.dto.MyEmoji;
 import reviewme.be.util.dto.QEmojiCount;
-import reviewme.be.util.dto.QMyEmoji;
 
 @RequiredArgsConstructor
 public class FeedbackEmojiRepositoryImpl implements FeedbackEmojiRepositoryCustom {
@@ -33,25 +31,7 @@ public class FeedbackEmojiRepositoryImpl implements FeedbackEmojiRepositoryCusto
             .innerJoin(feedbackEmoji.feedback, feedback)
             .where(feedbackEmoji.feedback.id.in(feedbackIds))
             .groupBy(emoji.id, feedback.id)
-            .orderBy(feedback.createdAt.desc(), emoji.id.asc())
-            .fetch();
-    }
-
-    @Override
-    public List<MyEmoji> findMyEmojiIdsByFeedbackIdIn(long userId, List<Long> feedbackIds) {
-
-        return queryFactory
-            .select(new QMyEmoji(
-                feedbackEmoji.emoji.id,
-                user.id)
-            )
-            .from(feedbackEmoji)
-            .leftJoin(feedbackEmoji.user, user)
-            .where(feedbackEmoji.feedback.id.in(feedbackIds)
-                .and(feedbackEmoji.user.id.eq(userId))
-                .or(user.id.isNull()))
-            .groupBy(feedbackEmoji.feedback.id)
-            .orderBy(feedbackEmoji.feedback.id.desc())
+            .orderBy(feedback.id.desc(), emoji.id.asc())
             .fetch();
     }
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackRepositoryImpl.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackRepositoryImpl.java
@@ -45,7 +45,7 @@ public class FeedbackRepositoryImpl implements FeedbackRepositoryCustom {
                 .and(feedback.deletedAt.isNull()
                     .or(feedback.deletedAt.isNotNull().and(feedback.childCnt.gt(0))))
             )
-            .orderBy(feedback.createdAt.desc())
+            .orderBy(feedback.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetchResults();
@@ -75,7 +75,7 @@ public class FeedbackRepositoryImpl implements FeedbackRepositoryCustom {
             .where(feedback.parentFeedback.id.eq(feedbackId)
                 .and(feedback.deletedAt.isNull())
             )
-            .orderBy(feedback.createdAt.desc())
+            .orderBy(feedback.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetchResults();

--- a/src/main/java/reviewme/be/feedback/service/FeedbackService.java
+++ b/src/main/java/reviewme/be/feedback/service/FeedbackService.java
@@ -94,8 +94,7 @@ public class FeedbackService {
         User user,
         Pageable pageable) {
 
-        Resume resume = resumeService.findById(resumeId);
-        boolean isWriter = resume.isWriter(user);
+        resumeService.findById(resumeId);
 
         // 피드백 목록 조회 후 id 목록 추출
         Page<FeedbackInfo> feedbackPage = feedbackRepository.findFeedbacksByResumeIdAndResumePage(
@@ -107,7 +106,7 @@ public class FeedbackService {
             feedbackEmojiRepository.findEmojiCountByFeedbackIds(feedbackIds));
 
         List<FeedbackResponse> feedbacksResponse = collectToFeedbacksResponse(feedbackIds,
-            feedbacks, emojiCounts, isWriter, user);
+            feedbacks, emojiCounts, user);
 
         return FeedbackPageResponse.builder()
             .feedbacks(feedbacksResponse)
@@ -230,7 +229,7 @@ public class FeedbackService {
 
     private List<FeedbackResponse> collectToFeedbacksResponse(List<Long> feedbackIds,
         List<FeedbackInfo> feedbacks,
-        List<List<EmojiCount>> emojiCounts, boolean isWriter, User user) {
+        List<List<EmojiCount>> emojiCounts, User user) {
 
         List<FeedbackResponse> feedbacksResponse = new ArrayList<>();
 
@@ -240,9 +239,8 @@ public class FeedbackService {
             List<EmojiCount> emojis = emojiCounts.get(feedbackIdx);
             Integer myEmojiId = findMyEmojiIdByFeedbackId(feedbackIds.get(feedbackIdx), user);
 
-            FeedbackResponse feedbackResponse = isWriter
-                ? FeedbackResponse.fromFeedbackOfOwnResume(feedback, emojis, myEmojiId)
-                : FeedbackResponse.fromFeedbackOfOthersResume(feedback, emojis, myEmojiId);
+            FeedbackResponse feedbackResponse = FeedbackResponse.fromFeedbackOfResume(feedback,
+                emojis, myEmojiId);
 
             feedbacksResponse.add(feedbackResponse);
         }
@@ -268,7 +266,8 @@ public class FeedbackService {
 
             FeedbackCommentInfo feedbackComment = feedbackComments.get(feedbackCommentIdx);
             List<EmojiCount> emojis = emojiCounts.get(feedbackCommentIdx);
-            Integer myEmojiId = findMyEmojiIdByFeedbackId(feedbackIds.get(feedbackCommentIdx), user);
+            Integer myEmojiId = findMyEmojiIdByFeedbackId(feedbackIds.get(feedbackCommentIdx),
+                user);
 
             feedbackCommentsResponse.add(
                 FeedbackCommentResponse.fromFeedbackComment(feedbackComment, emojis, myEmojiId)

--- a/src/main/java/reviewme/be/question/dto/response/QuestionResponse.java
+++ b/src/main/java/reviewme/be/question/dto/response/QuestionResponse.java
@@ -43,7 +43,6 @@ public class QuestionResponse {
     private long countOfReplies;
 
     @Schema(description = "체크 여부", example = "true")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean checked;
 
     @Schema(description = "북마크 여부", example = "true")
@@ -87,6 +86,7 @@ public class QuestionResponse {
             .labelContent(question.getLabelContent())
             .createdAt(question.getCreatedAt())
             .countOfReplies(question.getCountOfReplies())
+            .checked(question.isChecked())
             .emojis(emojis)
             .myEmojiId(myEmojiId)
             .build();

--- a/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
@@ -1,22 +1,11 @@
 package reviewme.be.question.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import reviewme.be.question.entity.QuestionEmoji;
-
-import javax.persistence.Tuple;
-import java.util.List;
 
 public interface QuestionEmojiRepository extends JpaRepository<QuestionEmoji, Long>, QuestionEmojiRepositoryCustom {
 
-    List<QuestionEmoji> findByQuestionId(long questionId);
+    Optional<QuestionEmoji> findByQuestionIdAndUserId(long questionId, long userId);
 
-    @Query(value = "SELECT emoji.id AS id, COUNT(emoji.id) AS count " +
-            "FROM QuestionEmoji questionEmoji " +
-            "JOIN questionEmoji.emoji emoji " +
-            "WHERE questionEmoji.question.id = :questionId " +
-            "GROUP BY emoji.id")
-    List<Tuple> countByQuestionIdGroupByEmojiId(long questionId);
-
-    QuestionEmoji findByQuestionIdAndUserId(long questionId, long userId);
 }

--- a/src/main/java/reviewme/be/question/repository/QuestionEmojiRepositoryImpl.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionEmojiRepositoryImpl.java
@@ -33,7 +33,7 @@ public class QuestionEmojiRepositoryImpl implements QuestionEmojiRepositoryCusto
             .innerJoin(questionEmoji.question, question)
             .where(questionEmoji.question.id.in(questionIds))
             .groupBy(emoji.id, question.id)
-            .orderBy(question.createdAt.desc(), emoji.id.asc())
+            .orderBy(question.id.desc(), emoji.id.asc())
             .fetch();
     }
 
@@ -51,7 +51,7 @@ public class QuestionEmojiRepositoryImpl implements QuestionEmojiRepositoryCusto
                 .and(questionEmoji.user.id.eq(userId))
                 .or(user.id.isNull()))
             .groupBy(questionEmoji.question.id)
-            .orderBy(questionEmoji.question.id.desc())
+            .orderBy(questionEmoji.id.desc(), questionEmoji.question.id.desc())
             .fetch();
     }
 }

--- a/src/main/java/reviewme/be/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionRepositoryImpl.java
@@ -45,7 +45,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
                 .and(question.deletedAt.isNull()
                     .or(question.deletedAt.isNotNull().and(question.childCnt.gt(0))))
             )
-            .orderBy(question.createdAt.desc())
+            .orderBy(question.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetchResults();
@@ -75,7 +75,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             .where(question.parentQuestion.id.eq(questionId)
                 .and(question.deletedAt.isNull())
             )
-            .orderBy(question.createdAt.desc())
+            .orderBy(question.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetchResults();

--- a/src/main/java/reviewme/be/resume/controller/ResumeController.java
+++ b/src/main/java/reviewme/be/resume/controller/ResumeController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import reviewme.be.resume.dto.request.ResumeSearchConditionParam;
 import reviewme.be.resume.dto.request.UpdateResumeRequest;
 import reviewme.be.resume.dto.request.UploadResumeRequest;
+import reviewme.be.resume.dto.response.MyResumePageResponse;
+import reviewme.be.resume.dto.response.MyResumeResponse;
 import reviewme.be.resume.dto.response.ResumeDetailResponse;
 import reviewme.be.resume.dto.response.ResumePageResponse;
 import reviewme.be.resume.dto.response.ResumeResponse;
@@ -38,76 +40,76 @@ public class ResumeController {
     @Operation(summary = "이력서 업로드", description = "이력서를 업로드합니다.")
     @PostMapping
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이력서 업로드 성공"),
-            @ApiResponse(responseCode = "400", description = "이력서 업로드 실패")
+        @ApiResponse(responseCode = "200", description = "이력서 업로드 성공"),
+        @ApiResponse(responseCode = "400", description = "이력서 업로드 실패")
     })
     public ResponseEntity<CustomResponse<UploadResumeResponse>> uploadResume(
-            @Parameter(description = "이력서 업로드 정보(파일 포함)", content = @Content(mediaType = "multipart/form-data", schema = @Schema(type = "file", format = "binary")))
-            @ModelAttribute UploadResumeRequest uploadResumeRequest,
-            @RequestAttribute("user") User user) {
+        @Parameter(description = "이력서 업로드 정보(파일 포함)", content = @Content(mediaType = "multipart/form-data", schema = @Schema(type = "file", format = "binary")))
+        @ModelAttribute UploadResumeRequest uploadResumeRequest,
+        @RequestAttribute("user") User user) {
 
         long id = resumeService.saveResume(uploadResumeRequest, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "이력서 업로드에 성공했습니다.",
-                        UploadResumeResponse.fromSavedResumeId(id)
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "이력서 업로드에 성공했습니다.",
+                UploadResumeResponse.fromSavedResumeId(id)
+            ));
     }
 
     @Operation(summary = "이력서 목록 조회", description = "이력서 목록을 조회합니다.")
     @GetMapping
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이력서 목록 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "이력서 목록 조회 실패")
+        @ApiResponse(responseCode = "200", description = "이력서 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "이력서 목록 조회 실패")
     })
     public ResponseEntity<CustomResponse<ResumePageResponse>> showResumes(
-            @PageableDefault(size=20) Pageable pageable,
-            @ModelAttribute ResumeSearchConditionParam searchCondition,
-            @RequestAttribute("user") User user) {
+        @PageableDefault(size = 20) Pageable pageable,
+        @ModelAttribute ResumeSearchConditionParam searchCondition,
+        @RequestAttribute("user") User user) {
 
         Page<ResumeResponse> resumes = resumeService.getResumes(searchCondition, pageable, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "이력서 목록 조회에 성공했습니다.",
-                        ResumePageResponse.fromResumePageable(resumes)
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "이력서 목록 조회에 성공했습니다.",
+                ResumePageResponse.fromResumePageable(resumes)
+            ));
     }
 
     @Operation(summary = "내 이력서 목록 조회", description = "내 이력서 목록을 조회합니다.")
     @GetMapping("/my")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "내 이력서 목록 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "내 이력서 목록 조회 실패")
+        @ApiResponse(responseCode = "200", description = "내 이력서 목록 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "내 이력서 목록 조회 실패")
     })
-    public ResponseEntity<CustomResponse<ResumePageResponse>> showMyResumes(
-            @PageableDefault(size=20) Pageable pageable,
-            @RequestAttribute("user") User user) {
+    public ResponseEntity<CustomResponse<MyResumePageResponse>> showMyResumes(
+        @PageableDefault(size = 20) Pageable pageable,
+        @RequestAttribute("user") User user) {
 
-//        Page<ResumeResponse> resumes = resumeService.getMyResumes(pageable, user);
+        Page<MyResumeResponse> myResumes = resumeService.getMyResumes(pageable, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "내 이력서 목록 조회에 성공했습니다."
-//                        ResumePageResponse.fromResumePageable(resumes)
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "내 이력서 목록 조회에 성공했습니다.",
+                MyResumePageResponse.fromMyResumePageable(myResumes)
+            ));
     }
 
     @Operation(summary = "이력서 상세 조회", description = "이력서 상세 내용을 조회합니다.")
     @GetMapping("/{resumeId}")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이력서 상세 내용 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "이력서 상세 내용 조회 실패")
+        @ApiResponse(responseCode = "200", description = "이력서 상세 내용 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "이력서 상세 내용 조회 실패")
     })
     public ResponseEntity<CustomResponse<ResumeDetailResponse>> showResumeDetail(
         @PathVariable long resumeId,
@@ -117,55 +119,55 @@ public class ResumeController {
         ResumeDetailResponse resumeDetail = resumeService.getResumeDetail(resumeId, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "이력서 상세 내용 조회에 성공했습니다.",
-                        resumeDetail
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "이력서 상세 내용 조회에 성공했습니다.",
+                resumeDetail
+            ));
     }
 
     @Operation(summary = "이력서 삭제", description = "이력서를 삭제합니다.")
     @DeleteMapping("/{resumeId}")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이력서 삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "이력서 삭제 실패")
+        @ApiResponse(responseCode = "200", description = "이력서 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "이력서 삭제 실패")
     })
     public ResponseEntity<CustomResponse<Void>> deleteResume(
-            @PathVariable long resumeId,
-            @RequestAttribute("user") User user) {
+        @PathVariable long resumeId,
+        @RequestAttribute("user") User user) {
 
         resumeService.deleteResume(resumeId, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "이력서 삭제에 성공했습니다."
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "이력서 삭제에 성공했습니다."
+            ));
     }
 
     @Operation(summary = "이력서 수정", description = "이력서를 수정합니다.")
     @PatchMapping("/{resumeId}")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "이력서 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "이력서 수정 실패")
+        @ApiResponse(responseCode = "200", description = "이력서 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "이력서 수정 실패")
     })
     public ResponseEntity<CustomResponse<Void>> updateResume(
-            @Validated @RequestBody UpdateResumeRequest updateResumeRequest,
-            @PathVariable Long resumeId,
-            @RequestAttribute("user") User user) {
+        @Validated @RequestBody UpdateResumeRequest updateResumeRequest,
+        @PathVariable Long resumeId,
+        @RequestAttribute("user") User user) {
 
         resumeService.updateResume(updateResumeRequest, resumeId, user);
 
         return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "이력서 수정에 성공했습니다."
-                ));
+            .ok()
+            .body(new CustomResponse<>(
+                "success",
+                200,
+                "이력서 수정에 성공했습니다."
+            ));
     }
 }

--- a/src/main/java/reviewme/be/resume/controller/ResumeController.java
+++ b/src/main/java/reviewme/be/resume/controller/ResumeController.java
@@ -81,6 +81,28 @@ public class ResumeController {
                 ));
     }
 
+    @Operation(summary = "내 이력서 목록 조회", description = "내 이력서 목록을 조회합니다.")
+    @GetMapping("/my")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 이력서 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "내 이력서 목록 조회 실패")
+    })
+    public ResponseEntity<CustomResponse<ResumePageResponse>> showMyResumes(
+            @PageableDefault(size=20) Pageable pageable,
+            @RequestAttribute("user") User user) {
+
+//        Page<ResumeResponse> resumes = resumeService.getMyResumes(pageable, user);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "내 이력서 목록 조회에 성공했습니다."
+//                        ResumePageResponse.fromResumePageable(resumes)
+                ));
+    }
+
     @Operation(summary = "이력서 상세 조회", description = "이력서 상세 내용을 조회합니다.")
     @GetMapping("/{resumeId}")
     @ApiResponses({

--- a/src/main/java/reviewme/be/resume/dto/ResumeSearchCondition.java
+++ b/src/main/java/reviewme/be/resume/dto/ResumeSearchCondition.java
@@ -14,17 +14,21 @@ public class ResumeSearchCondition {
 
     private Integer scope;
     private Integer occupation;
-    private Integer year;
+    private Integer startYear;
+    private Integer endYear;
 
     public ResumeSearchCondition(ResumeSearchConditionParam resumeSearchConditionParam) {
 
         // Default scope is 2 (public, friends only)
         this.scope = 2;
         this.occupation = resumeSearchConditionParam.getOccupation();
-        this.year = resumeSearchConditionParam.getYear();
+        this.startYear = resumeSearchConditionParam.getStartYear();
+        this.endYear = resumeSearchConditionParam.getEndYear();
     }
 
     public void onlyPublic() {
+
+        // is public only
         this.scope = 1;
     }
 }

--- a/src/main/java/reviewme/be/resume/dto/request/ResumeSearchConditionParam.java
+++ b/src/main/java/reviewme/be/resume/dto/request/ResumeSearchConditionParam.java
@@ -10,5 +10,6 @@ import lombok.Setter;
 public class ResumeSearchConditionParam {
     
     private Integer occupation;
-    private Integer year;
+    private Integer startYear;
+    private Integer endYear;
 }

--- a/src/main/java/reviewme/be/resume/dto/response/MyResumePageResponse.java
+++ b/src/main/java/reviewme/be/resume/dto/response/MyResumePageResponse.java
@@ -1,0 +1,35 @@
+package reviewme.be.resume.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@Schema(description = "이력서 목록 응답")
+public class MyResumePageResponse {
+
+    @Schema(description = "이력서 목록")
+    private List<MyResumeResponse> resumes;
+
+    @Schema(description = "현재 페이지", example = "1")
+    private int pageNumber;
+
+    @Schema(description = "페이징 적용 시 전체 페이지 수", example = "1")
+    private int lastPage;
+
+    @Schema(description = "페이징 적용 시 한 번에 받아오는 데이터 개수", example = "1")
+    private int pageSize;
+
+    public static MyResumePageResponse fromMyResumePageable(Page<MyResumeResponse> resumePage) {
+
+        return MyResumePageResponse.builder()
+                .resumes(resumePage.getContent())
+                .pageNumber(resumePage.getNumber())
+                .lastPage(resumePage.getTotalPages() - 1)
+                .pageSize(resumePage.getSize())
+                .build();
+    }
+}

--- a/src/main/java/reviewme/be/resume/dto/response/MyResumeResponse.java
+++ b/src/main/java/reviewme/be/resume/dto/response/MyResumeResponse.java
@@ -1,0 +1,57 @@
+package reviewme.be.resume.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import reviewme.be.resume.entity.Resume;
+
+@Getter
+@Builder
+@Schema(description = "이력서 목록 페이지 응답")
+public class MyResumeResponse {
+
+    @Schema(description = "이력서 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "이력서 제목", example = "네이버 신입 개발자 준비")
+    private String title;
+
+    @Schema(description = "이력서 작성 시간", example = "2024-01-02 01:32")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "공개 범위", example = "public")
+    private String scope;
+
+    @Schema(description = "직군", example = "1")
+    private String occupation;
+
+    @Schema(description = "년차", example = "0")
+    private Integer year;
+
+    public static MyResumeResponse fromResume(Resume resume) {
+
+        return MyResumeResponse.builder()
+                .id(resume.getId())
+                .title(resume.getTitle())
+                .createdAt(resume.getCreatedAt())
+                .scope(resume.getScope().getScope())
+                .occupation(resume.getOccupation().getOccupation())
+                .year(resume.getYear())
+                .build();
+    }
+
+    @QueryProjection
+    public MyResumeResponse(Long id, String title, LocalDateTime createdAt, String scope, String occupation, Integer year) {
+
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.scope = scope;
+        this.occupation = occupation;
+        this.year = year;
+    }
+}

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepository.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepository.java
@@ -12,5 +12,4 @@ public interface ResumeRepository extends JpaRepository<Resume, Long>, ResumeRep
     Optional<Resume> findByIdAndDeletedAtIsNull(long id);
 
     Optional<Resume> findByUrlAndDeletedAtIsNull(String url);
-    List<Resume> findByWriterIdAndDeletedAtIsNull(long userId);
 }

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
@@ -3,10 +3,12 @@ package reviewme.be.resume.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import reviewme.be.resume.dto.ResumeSearchCondition;
+import reviewme.be.resume.dto.response.MyResumeResponse;
 import reviewme.be.resume.dto.response.ResumeResponse;
 
 public interface ResumeRepositoryCustom {
 
     Page<ResumeResponse> findResumes(ResumeSearchCondition searchCondition, Pageable pageable);
 
+    Page<MyResumeResponse> findResumesByWriterId(Pageable pageable, long userId);
 }

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
@@ -7,6 +7,6 @@ import reviewme.be.resume.dto.response.ResumeResponse;
 
 public interface ResumeRepositoryCustom {
 
-    Page<ResumeResponse> findAllByDeletedAtIsNull(ResumeSearchCondition searchCondition, Pageable pageable);
+    Page<ResumeResponse> findResumes(ResumeSearchCondition searchCondition, Pageable pageable);
 
 }

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import reviewme.be.resume.dto.ResumeSearchCondition;
+import reviewme.be.resume.dto.response.MyResumeResponse;
+import reviewme.be.resume.dto.response.QMyResumeResponse;
 import reviewme.be.resume.dto.response.QResumeResponse;
 import reviewme.be.resume.dto.response.ResumeResponse;
 
@@ -46,12 +48,43 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                         yearLoe(searchCondition.getEndYear()),
                         resume.deletedAt.isNull()
                 )
-                .orderBy(resume.createdAt.desc())
+                .orderBy(resume.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchResults();
 
         List<ResumeResponse> content = results.getResults();
+        long total = results.getTotal();
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    @Override
+    public Page<MyResumeResponse> findResumesByWriterId(Pageable pageable, long userId) {
+
+        QueryResults<MyResumeResponse> results = queryFactory
+                .select(new QMyResumeResponse(
+                        resume.id,
+                        resume.title,
+                        resume.createdAt,
+                        resume.scope.scope,
+                        resume.occupation.occupation,
+                        resume.year
+                ))
+                .from(resume)
+                .leftJoin(resume.writer)
+                .leftJoin(resume.scope)
+                .leftJoin(resume.occupation)
+                .where(
+                        resume.writer.id.eq(userId),
+                        resume.deletedAt.isNull()
+                )
+                .orderBy(resume.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+
+        List<MyResumeResponse> content = results.getResults();
         long total = results.getTotal();
 
         return new PageImpl<>(content, pageable, total);

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
@@ -42,8 +42,10 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                 .where(
                         scopeIdEq(searchCondition.getScope()),
                         occupationEq(searchCondition.getOccupation()),
-                        yearEq(searchCondition.getYear()),
-                        resume.deletedAt.isNull())
+                        yearGoe(searchCondition.getStartYear()),
+                        yearLoe(searchCondition.getEndYear()),
+                        resume.deletedAt.isNull()
+                )
                 .orderBy(resume.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -65,8 +67,13 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
         return occupationId != null ? resume.occupation.id.eq(occupationId) : null;
     }
 
-    private BooleanExpression yearEq(Integer year) {
+    private BooleanExpression yearGoe(Integer startYear) {
 
-        return year != null ? resume.year.eq(year) : null;
+        return startYear != null ? resume.year.goe(startYear) : null;
+    }
+
+    private BooleanExpression yearLoe(Integer endYear) {
+
+        return endYear != null ? resume.year.loe(endYear) : null;
     }
 }

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
@@ -21,7 +21,7 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<ResumeResponse> findAllByDeletedAtIsNull(ResumeSearchCondition searchCondition, Pageable pageable) {
+    public Page<ResumeResponse> findResumes(ResumeSearchCondition searchCondition, Pageable pageable) {
 
         QueryResults<ResumeResponse> results = queryFactory
                 .select(new QResumeResponse(
@@ -42,7 +42,8 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                 .where(
                         scopeIdEq(searchCondition.getScope()),
                         occupationEq(searchCondition.getOccupation()),
-                        yearEq(searchCondition.getYear()))
+                        yearEq(searchCondition.getYear()),
+                        resume.deletedAt.isNull())
                 .orderBy(resume.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/reviewme/be/resume/service/ResumeService.java
+++ b/src/main/java/reviewme/be/resume/service/ResumeService.java
@@ -69,8 +69,7 @@ public class ResumeService {
             searchCondition.onlyPublic();
         }
 
-        // TODO: 조회 쿼리 수정 필요
-        return resumeRepository.findAllByDeletedAtIsNull(searchCondition, pageable);
+        return resumeRepository.findResumes(searchCondition, pageable);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import reviewme.be.custom.CustomErrorResponse;
 import reviewme.be.util.exception.NonExistLabelException;
 import reviewme.be.util.exception.NonExistOccupationException;
 import reviewme.be.util.exception.NonExistScopeException;
+import reviewme.be.util.exception.NotLoggedInUserException;
 import reviewme.be.util.exception.NotYoursException;
 
 @RestControllerAdvice
@@ -104,6 +105,17 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotYoursException.class)
     public ResponseEntity<CustomErrorResponse> notYours(NotYoursException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "Bad Request",
+                        400,
+                        ex.getMessage()));
+    }
+
+    @ExceptionHandler(NotLoggedInUserException.class)
+    public ResponseEntity<CustomErrorResponse> notLoggedInUser(NotLoggedInUserException ex) {
 
         return ResponseEntity
                 .badRequest()

--- a/src/main/java/reviewme/be/util/exception/NotLoggedInUserException.java
+++ b/src/main/java/reviewme/be/util/exception/NotLoggedInUserException.java
@@ -1,0 +1,9 @@
+package reviewme.be.util.exception;
+
+public class NotLoggedInUserException extends RuntimeException {
+
+    public NotLoggedInUserException(String message) {
+
+        super(message);
+    }
+}


### PR DESCRIPTION
## 개요
- 내 이력서 목록을 조회할 수 있다.
- 전체 이력서 목록 조회 시 년차를 기준으로 필터링할 수 있다.

## 작업 사항
- 페이징 요청 시 최대 size 설정 추가
- 비로그인 사용자, 이력서 주인이 아닌 사용자에게 checked 표시 응답 추가
- 내 이력서 목록 조회 API 
   - 비로그인 사용자 요청 시 예외 처리

## 이슈 번호
- #72 