### PR TITLE
[이모지] 이모지 수정 API 추가

### DIFF
--- a/src/main/java/reviewme/be/comment/controller/CommentController.java
+++ b/src/main/java/reviewme/be/comment/controller/CommentController.java
@@ -129,7 +129,7 @@ public class CommentController {
         @PathVariable long commentId,
         @RequestAttribute("user") User user) {
 
-        commentService.updateCommentEmoji(updateCommentEmojiRequest, commentId, user);
+        commentService.updateCommentEmoji(updateCommentEmojiRequest, resumeId, commentId, user);
 
         return ResponseEntity
             .ok()

--- a/src/main/java/reviewme/be/comment/repository/CommentRepository.java
+++ b/src/main/java/reviewme/be/comment/repository/CommentRepository.java
@@ -7,4 +7,6 @@ import reviewme.be.comment.entity.Comment;
 public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 
     Optional<Comment> findByIdAndDeletedAtIsNull(long commentId);
+
+    Optional<Comment> findByIdAndResumeIdAndDeletedAtIsNull(long commentId, long resumeId);
 }

--- a/src/main/java/reviewme/be/comment/service/CommentService.java
+++ b/src/main/java/reviewme/be/comment/service/CommentService.java
@@ -43,13 +43,13 @@ public class CommentService {
     private final EmojisVO emojisVO;
 
     @Transactional
-    public void saveComment(User commenter, long resumeId, PostCommentRequest postComment) {
+    public void saveComment(User commenter, long resumeId, PostCommentRequest request) {
 
         Resume resume = resumeService.findById(resumeId);
         LocalDateTime createdAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         Comment savedComment = commentRepository.save(
-            new Comment(commenter, resume, postComment.getContent(), createdAt)
+            new Comment(commenter, resume, request.getContent(), createdAt)
         );
 
         // Default Comment Emojis 생성
@@ -105,7 +105,7 @@ public class CommentService {
     }
 
     @Transactional
-    public void updateComment(UpdateCommentContentRequest updateComment, User user, long resumeId,
+    public void updateComment(UpdateCommentContentRequest request, User user, long resumeId,
         long commentId) {
 
         resumeService.findById(resumeId);
@@ -113,11 +113,11 @@ public class CommentService {
         Comment comment = findById(commentId);
         comment.validateUser(user);
 
-        comment.updateContent(updateComment.getContent(), LocalDateTime.now());
+        comment.updateContent(request.getContent(), LocalDateTime.now());
     }
 
     @Transactional
-    public void updateCommentEmoji(UpdateCommentEmojiRequest updateCommentEmoji,
+    public void updateCommentEmoji(UpdateCommentEmojiRequest request,
         long resumeId, long commentId, User user) {
 
         // 이력서로 댓글 존재 여부 검증
@@ -129,7 +129,7 @@ public class CommentService {
                 commentEmojiRepository::delete
             );
 
-        Integer emojiId = updateCommentEmoji.getId();
+        Integer emojiId = request.getId();
 
         if (emojiId == null) return;
 

--- a/src/main/java/reviewme/be/comment/service/CommentService.java
+++ b/src/main/java/reviewme/be/comment/service/CommentService.java
@@ -23,14 +23,12 @@ import reviewme.be.user.entity.User;
 import reviewme.be.user.service.UserService;
 import reviewme.be.util.dto.EmojiCount;
 import reviewme.be.util.entity.Emoji;
-import reviewme.be.util.exception.NonExistEmojiException;
 import reviewme.be.util.service.UtilService;
 import reviewme.be.util.vo.EmojisVO;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -76,8 +74,9 @@ public class CommentService {
             commentEmojiRepository.findEmojiCountByCommentIds(commentIds));
 
         // 내가 선택한 이모지 목록 조회
-        List<Integer> myEmojiIds = utilService.getMyEmojiIds(commentEmojiRepository.findByUserIdAndCommentIdIn(
-            user.getId(), commentIds));
+        List<Integer> myEmojiIds = utilService.getMyEmojiIds(
+            commentEmojiRepository.findByUserIdAndCommentIdIn(
+                user.getId(), commentIds));
 
         List<CommentResponse> commentsResponse = collectToCommentsResponse(commentIds, comments,
             emojiCounts, myEmojiIds);
@@ -119,35 +118,37 @@ public class CommentService {
 
     @Transactional
     public void updateCommentEmoji(UpdateCommentEmojiRequest updateCommentEmoji,
-        long commentId, User user) {
+        long resumeId, long commentId, User user) {
 
-        Comment comment = findById(commentId);
+        // 이력서로 댓글 존재 여부 검증
+        Comment comment = findByIdAndResumeId(commentId, resumeId);
+
+        // 기존 이모지 삭제
+        commentEmojiRepository.findByUserIdAndCommentId(user.getId(), commentId)
+            .ifPresent(
+                commentEmojiRepository::delete
+            );
 
         Integer emojiId = updateCommentEmoji.getId();
 
-        Optional<CommentEmoji> myCommentEmoji = commentEmojiRepository.findByUserIdAndCommentId(
-            user.getId(), commentId);
+        if (emojiId == null) return;
 
         Emoji emoji = emojisVO.findEmojiById(emojiId);
 
-        if (myCommentEmoji.isEmpty()) {
-            commentEmojiRepository.save(CommentEmoji.ofCreated(
-                userService.getUserById(user.getId()),
-                comment,
-                emoji));
-            return;
-        }
-
-        if (emojiId != null && !emojisVO.validateEmojiById(emojiId)) {
-            throw new NonExistEmojiException("존재하지 않는 이모지입니다.");
-        }
-
-        myCommentEmoji.get().updateEmoji(emoji);
+        commentEmojiRepository.save(
+            CommentEmoji.ofCreated(user, comment, emoji)
+        );
     }
 
     private Comment findById(long commentId) {
 
         return commentRepository.findByIdAndDeletedAtIsNull(commentId)
+            .orElseThrow(() -> new NonExistCommentException("존재하지 않는 댓글입니다."));
+    }
+
+    private Comment findByIdAndResumeId(long commentId, long resumeId) {
+
+        return commentRepository.findByIdAndResumeIdAndDeletedAtIsNull(commentId, resumeId)
             .orElseThrow(() -> new NonExistCommentException("존재하지 않는 댓글입니다."));
     }
 

--- a/src/main/java/reviewme/be/feedback/controller/FeedbackController.java
+++ b/src/main/java/reviewme/be/feedback/controller/FeedbackController.java
@@ -12,8 +12,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import reviewme.be.feedback.dto.request.*;
 import reviewme.be.feedback.dto.response.*;
-import reviewme.be.feedback.repository.FeedbackEmojiRepository;
-import reviewme.be.feedback.repository.FeedbackRepository;
 import reviewme.be.custom.CustomResponse;
 import reviewme.be.feedback.service.FeedbackService;
 import reviewme.be.user.entity.User;
@@ -25,8 +23,6 @@ import reviewme.be.user.entity.User;
 public class FeedbackController {
 
     private final FeedbackService feedbackService;
-    private final FeedbackRepository feedbackRepository;
-    private final FeedbackEmojiRepository feedbackEmojiRepository;
 
     @Operation(summary = "피드백 추가", description = "피드백을 추가합니다.")
     @PostMapping
@@ -130,12 +126,12 @@ public class FeedbackController {
         @ApiResponse(responseCode = "200", description = "피드백 삭제 성공"),
         @ApiResponse(responseCode = "400", description = "피드백 삭제 실패")
     })
-    public ResponseEntity<CustomResponse> deleteFeedback(
+    public ResponseEntity<CustomResponse<Void>> deleteFeedback(
         @PathVariable long resumeId,
         @PathVariable long feedbackId,
         @RequestAttribute("user") User user) {
 
-        feedbackService.deleteFeedback(user, resumeId, feedbackId);
+        feedbackService.deleteFeedback(resumeId, feedbackId, user);
 
         return ResponseEntity
             .ok()
@@ -152,14 +148,14 @@ public class FeedbackController {
         @ApiResponse(responseCode = "200", description = "피드백 수정 성공"),
         @ApiResponse(responseCode = "400", description = "피드백 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateFeedbackContent(
+    public ResponseEntity<CustomResponse<Void>> updateFeedbackContent(
         @Validated @RequestBody UpdateFeedbackContentRequest updateFeedbackContentRequest,
         @RequestAttribute("user") User user,
         @PathVariable long resumeId,
         @PathVariable long feedbackId) {
 
-        feedbackService.updateFeedbackContent(updateFeedbackContentRequest, user, resumeId,
-            feedbackId);
+        feedbackService.updateFeedbackContent(updateFeedbackContentRequest, resumeId,
+            feedbackId, user);
 
         return ResponseEntity
             .ok()
@@ -176,7 +172,7 @@ public class FeedbackController {
         @ApiResponse(responseCode = "200", description = "피드백 체크 상태 수정 성공"),
         @ApiResponse(responseCode = "400", description = "피드백 체크 상태 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateFeedbackCheck(
+    public ResponseEntity<CustomResponse<Void>> updateFeedbackCheck(
         @Validated @RequestBody UpdateFeedbackCheckRequest updateFeedbackCheckRequest,
         @PathVariable long resumeId,
         @PathVariable long feedbackId,
@@ -199,10 +195,13 @@ public class FeedbackController {
         @ApiResponse(responseCode = "200", description = "피드백 이모지 수정 성공"),
         @ApiResponse(responseCode = "400", description = "피드백 이모지 수정 실패")
     })
-    public ResponseEntity<CustomResponse> updateFeedbackEmoji(
-        @Validated @RequestBody UpdateFeedbackEmojiRequest updateFeedbackEmojiRequest,
+    public ResponseEntity<CustomResponse<Void>> updateFeedbackEmoji(
+        @RequestBody UpdateFeedbackEmojiRequest updateFeedbackEmojiRequest,
         @PathVariable long resumeId,
-        @PathVariable long feedbackId) {
+        @PathVariable long feedbackId,
+        @RequestAttribute("user") User user) {
+
+        feedbackService.updateFeedbackEmoji(updateFeedbackEmojiRequest, resumeId, feedbackId, user);
 
         return ResponseEntity
             .ok()

--- a/src/main/java/reviewme/be/feedback/dto/request/UpdateFeedbackEmojiRequest.java
+++ b/src/main/java/reviewme/be/feedback/dto/request/UpdateFeedbackEmojiRequest.java
@@ -13,6 +13,5 @@ import javax.validation.constraints.NotNull;
 public class UpdateFeedbackEmojiRequest {
 
     @Schema(description = "피드백 이모지 ID", example = "1")
-    @NotNull(message = "피드백 이모지 ID는 필수 입력 값입니다.")
-    private Long id;
+    private Integer id;
 }

--- a/src/main/java/reviewme/be/feedback/entity/FeedbackEmoji.java
+++ b/src/main/java/reviewme/be/feedback/entity/FeedbackEmoji.java
@@ -31,6 +31,12 @@ public class FeedbackEmoji {
     @JoinColumn(name = "emoji_id")
     private Emoji emoji;
 
+    public FeedbackEmoji(User user, Feedback feedback, Emoji emoji) {
+        this.user = user;
+        this.feedback = feedback;
+        this.emoji = emoji;
+    }
+
     public static List<FeedbackEmoji> createDefaultFeedbackEmojis(Feedback feedback,
         List<Emoji> emojis) {
 

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
@@ -8,5 +8,7 @@ public interface FeedbackEmojiRepository extends JpaRepository<FeedbackEmoji, Lo
 
     Optional<FeedbackEmoji> findByFeedbackIdAndUserId(long feedbackId, long userId);
 
+    Optional<FeedbackEmoji> findByUserIdAndFeedbackId(long userId, long feedbackId);
+
     void deleteAllByFeedbackId(long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
@@ -8,7 +8,5 @@ public interface FeedbackEmojiRepository extends JpaRepository<FeedbackEmoji, Lo
 
     Optional<FeedbackEmoji> findByFeedbackIdAndUserId(long feedbackId, long userId);
 
-    Optional<FeedbackEmoji> findByUserIdAndFeedbackId(long userId, long feedbackId);
-
     void deleteAllByFeedbackId(long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/service/FeedbackService.java
+++ b/src/main/java/reviewme/be/feedback/service/FeedbackService.java
@@ -204,7 +204,7 @@ public class FeedbackService {
         Feedback feedback = findByIdAndResumeId(feedbackId, resumeId);
 
         // 기존 이모지 삭제
-        feedbackEmojiRepository.findByUserIdAndFeedbackId(user.getId(), feedbackId)
+        feedbackEmojiRepository.findByFeedbackIdAndUserId(feedbackId, user.getId())
             .ifPresent(
                 feedbackEmojiRepository::delete
             );

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -253,8 +253,12 @@ public class QuestionController {
         @ApiResponse(responseCode = "400", description = "예상 질문 이모지 상태 수정 실패")
     })
     public ResponseEntity<CustomResponse<Void>> updateQuestionEmoji(
-        @Validated @RequestBody UpdateQuestionEmojiRequest updateQuestionEmojiRequest,
-        @PathVariable long resumeId, @PathVariable long questionId) {
+        @RequestBody UpdateQuestionEmojiRequest updateQuestionEmojiRequest,
+        @PathVariable long resumeId,
+        @PathVariable long questionId,
+        @RequestAttribute("user") User user) {
+
+        questionService.updateQuestionEmoji(updateQuestionEmojiRequest, resumeId, questionId, user);
 
         return ResponseEntity
             .ok()

--- a/src/main/java/reviewme/be/question/dto/request/UpdateQuestionEmojiRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/UpdateQuestionEmojiRequest.java
@@ -3,8 +3,6 @@ package reviewme.be.question.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -13,6 +11,5 @@ import javax.validation.constraints.NotNull;
 public class UpdateQuestionEmojiRequest {
 
     @Schema(description = "예상 질문 이모지 ID", example = "1")
-    @NotNull(message = "예상 질문 이모지 ID는 필수 입력 값입니다.")
-    private Long id;
+    private Integer id;
 }

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -99,9 +99,9 @@ public class Question {
         this.bookmarked = bookmarked;
     }
 
-    public void softDelete() {
+    public void softDelete(LocalDateTime deletedAt) {
 
-        this.deletedAt = LocalDateTime.now();
+        this.deletedAt = deletedAt;
     }
 
     public boolean isParentQuestion() {

--- a/src/main/java/reviewme/be/question/entity/QuestionEmoji.java
+++ b/src/main/java/reviewme/be/question/entity/QuestionEmoji.java
@@ -31,6 +31,12 @@ public class QuestionEmoji {
     @JoinColumn(name = "emoji_id")
     private Emoji emoji;
 
+    public QuestionEmoji(User user, Question question, Emoji emoji) {
+        this.user = user;
+        this.question = question;
+        this.emoji = emoji;
+    }
+
     public static List<QuestionEmoji> createDefaultQuestionEmojis(Question question,
         List<Emoji> emojis) {
 

--- a/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
@@ -8,4 +8,5 @@ public interface QuestionEmojiRepository extends JpaRepository<QuestionEmoji, Lo
 
     Optional<QuestionEmoji> findByQuestionIdAndUserId(long questionId, long userId);
 
+    void deleteAllByQuestionId(long questionId);
 }

--- a/src/main/java/reviewme/be/user/controller/UserController.java
+++ b/src/main/java/reviewme/be/user/controller/UserController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reviewme.be.custom.CustomResponse;
@@ -202,12 +203,15 @@ public class UserController {
 
     private void setRefreshToken(HttpServletResponse response, String refreshToken) {
 
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setMaxAge(60 * 60 * 24 * 14);
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(60 * 60 * 24 * 14)
+            .sameSite("None")
+            .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     private String findRefreshTokenFromRequest(HttpServletRequest request) {

--- a/src/main/java/reviewme/be/util/vo/EmojisVO.java
+++ b/src/main/java/reviewme/be/util/vo/EmojisVO.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import reviewme.be.util.entity.Emoji;
+import reviewme.be.util.exception.NonExistEmojiException;
 import reviewme.be.util.repository.EmojiRepository;
 
 import javax.annotation.PostConstruct;
@@ -40,10 +41,10 @@ public class EmojisVO {
         return emojis.containsKey(emojiId);
     }
 
-    public Emoji findEmojiById(Integer emojiId) {
+    public Emoji findEmojiById(int emojiId) {
 
-        if (emojiId != null && !validateEmojiById(emojiId)) {
-            throw new IllegalArgumentException("존재하지 않는 이모지입니다.");
+        if (!validateEmojiById(emojiId)) {
+            throw new NonExistEmojiException("존재하지 않는 emojiId입니다.");
         }
 
         return emojis.get(emojiId);


### PR DESCRIPTION
## 개요
- 사용자는 댓글, 피드백, 예상 질문, 대댓글에 이모지를 선택, 취소, 변경할 수 있다.

## 작업 사항
- 기존에 선택한 이모지가 있다면 삭제 후,
- 요청 시 id가 없다면 return
- id가 있다면 추가

## 이슈 번호
- #73 