### PR TITLE
[chore] 회의 후 변경 사항 반영

### DIFF
--- a/src/main/java/reviewme/be/config/CorsConfig.java
+++ b/src/main/java/reviewme/be/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
             .allowedOrigins("https://review-me.co.kr", "https://www.review-me.co.kr",
                 "https://127.0.0.1:8080", "http://127.0.0.1:8080")
-            .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(),
+            .allowedMethods(HttpMethod.GET.name(), HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.PATCH.name(),
                 HttpMethod.DELETE.name(), HttpMethod.OPTIONS.name())
             .allowedHeaders("Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization")
             .allowCredentials(true);

--- a/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
+++ b/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
@@ -3,6 +3,7 @@ package reviewme.be.config.interceptor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import reviewme.be.user.dto.response.UserProfileResponse;
@@ -13,6 +14,7 @@ import reviewme.be.user.exception.NoValidBearerFormatException;
 import reviewme.be.user.service.JWTService;
 import reviewme.be.user.service.UserService;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DefaultInterceptor implements HandlerInterceptor {
@@ -28,6 +30,8 @@ public class DefaultInterceptor implements HandlerInterceptor {
         if (header == null) {
             throw new NoValidBearerFormatException("Authorization header가 존재하지 않습니다.");
         }
+
+        log.info("Authorization header: {}", header);
 
         if (request.getHeader("Authorization").split(" ").length != 2) {
             throw new NoValidBearerFormatException("Bearer 토큰이 존재하지 않습니다.");

--- a/src/main/java/reviewme/be/feedback/dto/response/FeedbackResponse.java
+++ b/src/main/java/reviewme/be/feedback/dto/response/FeedbackResponse.java
@@ -1,7 +1,6 @@
 package reviewme.be.feedback.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -39,7 +38,7 @@ public class FeedbackResponse {
     private LocalDateTime createdAt;
 
     @Schema(description = "댓글 개수", example = "10")
-    private long countOfComments;
+    private long countOfReplies;
 
     @Schema(description = "체크 여부", example = "true")
     private Boolean checked;
@@ -61,7 +60,7 @@ public class FeedbackResponse {
             .commenterProfileUrl(feedback.getCommenterProfileUrl())
             .labelContent(feedback.getLabelContent())
             .createdAt(feedback.getCreatedAt())
-            .countOfComments(feedback.getCountOfReplies())
+            .countOfReplies(feedback.getCountOfReplies())
             .checked(feedback.isChecked())
             .emojis(emojis)
             .myEmojiId(myEmojiId)

--- a/src/main/java/reviewme/be/question/dto/request/CreateQuestionRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/CreateQuestionRequest.java
@@ -1,6 +1,7 @@
 package reviewme.be.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Max;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -17,10 +18,8 @@ public class CreateQuestionRequest {
     @NotBlank(message = "예상 질문 내용은 필수 입력 값입니다.")
     private String content;
 
-    @Schema(description = "라벨 ID", example = "1", required = false)
-    private Long labelId;
-
     @Schema(description = "라벨 내용", example = "react-query", required = false)
+    @Max(value = 20, message = "라벨 내용은 20자 이하로 입력해야 합니다.")
     private String labelContent;
 
     @Schema(description = "이력서 페이지", example = "1")

--- a/src/main/java/reviewme/be/question/dto/request/CreateQuestionRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/CreateQuestionRequest.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Builder
@@ -19,7 +20,7 @@ public class CreateQuestionRequest {
     private String content;
 
     @Schema(description = "라벨 내용", example = "react-query", required = false)
-    @Max(value = 20, message = "라벨 내용은 20자 이하로 입력해야 합니다.")
+    @Length(max = 20, message = "라벨 내용은 20자 이하여야 합니다.")
     private String labelContent;
 
     @Schema(description = "이력서 페이지", example = "1")

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -217,7 +217,9 @@ public class QuestionService {
 
         Integer emojiId = request.getId();
 
-        if (emojiId == null) return;
+        if (emojiId == null) {
+            return;
+        }
 
         Emoji emoji = emojisVO.findEmojiById(emojiId);
 
@@ -243,11 +245,6 @@ public class QuestionService {
      * @return
      */
     private Label verifyQuestionLabel(CreateQuestionRequest request, Resume resume) {
-
-        if (request.getLabelId() != null) {
-
-            return utilService.findById(request.getLabelId());
-        }
 
         if (request.getLabelContent() != null && !request.getLabelContent().isEmpty()) {
 

--- a/src/main/java/reviewme/be/user/controller/UserController.java
+++ b/src/main/java/reviewme/be/user/controller/UserController.java
@@ -48,14 +48,12 @@ public class UserController {
         @ApiResponse(responseCode = "200", description = "로그인 성공"),
         @ApiResponse(responseCode = "400", description = "로그인 실패")
     })
-    public ResponseEntity<CustomResponse<LoginUserResponse>> loginWithGitHub(
+    public ResponseEntity<CustomResponse<Void>> loginWithGitHub(
         @RequestBody OAuthCodeRequest request,
         HttpServletResponse response) {
 
         UserGitHubToken userGitHubToken = oauthLoginService.getUserGitHubToken(request.getCode());
 
-        String jwt = createJwtByGitHubToken(userGitHubToken.getAccessToken(), userGitHubToken.getExpiresIn());
-
         setRefreshToken(response, userGitHubToken.getRefreshToken());
 
         return ResponseEntity
@@ -63,68 +61,7 @@ public class UserController {
             .body(new CustomResponse<>(
                 "success",
                 200,
-                "로그인에 성공했습니다.",
-                LoginUserResponse.builder()
-                    .jwt(jwt)
-                    .build()
-            ));
-    }
-
-    @Operation(summary = "사용자 토큰 새로고침", description = "기한이 만료된 토큰을 새로 만듭니다.")
-    @PostMapping("/user/refresh")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "토큰 새로 받기 성공"),
-        @ApiResponse(responseCode = "400", description = "토큰 새로 받기 실패")
-    })
-    public ResponseEntity<CustomResponse<LoginUserResponse>> refreshJwt(
-        HttpServletRequest request,
-        HttpServletResponse response) {
-
-        String refreshToken = findRefreshTokenFromRequest(request);
-
-        UserRefreshedToken userRefreshedToken = oauthLoginService.getUserRefreshedToken(
-            refreshToken);
-        String jwt = createJwtByGitHubToken(userRefreshedToken.getAccessToken(), userRefreshedToken.getExpiresIn());
-
-        setRefreshToken(response, userRefreshedToken.getRefreshToken());
-
-        return ResponseEntity
-            .ok()
-            .body(new CustomResponse<>(
-                "success",
-                200,
-                "로그인에 성공했습니다.",
-                LoginUserResponse.builder()
-                    .jwt(jwt)
-                    .build()
-            ));
-    }
-
-    @Operation(summary = "GitHub으로 로그인", description = "GitHub 계정을 통해 사용자가 로그인합니다.")
-    @GetMapping("/login/oauth")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "로그인 성공"),
-        @ApiResponse(responseCode = "400", description = "로그인 실패")
-    })
-    public ResponseEntity<CustomResponse<LoginUserResponse>> getLoginWithGitHub(
-        @RequestParam("code") String code,
-        HttpServletResponse response) {
-
-        UserGitHubToken userGitHubToken = oauthLoginService.getUserGitHubToken(code);
-
-        String jwt = createJwtByGitHubToken(userGitHubToken.getAccessToken(), userGitHubToken.getExpiresIn());
-
-        setRefreshToken(response, userGitHubToken.getRefreshToken());
-
-        return ResponseEntity
-            .ok()
-            .body(new CustomResponse<>(
-                "success",
-                200,
-                "로그인에 성공했습니다.",
-                LoginUserResponse.builder()
-                    .jwt(jwt)
-                    .build()
+                "로그인에 성공했습니다."
             ));
     }
 


### PR DESCRIPTION
## 개요

## 작업 사항
- request header에 authorization은 있지만 value가 없는 경우 해결을 위한 log 추가
- 예상 질문 추가 시 labelContent만 보내도록 함, cors에 PATCH 메서드 추가 허용
   - 최대 길이 validation 추가
- FE 요구에 따라 로그인 API에서 response 시 jwt 제거, token refresh API를 GET method로 변경
-  대댓글 개수에 대한 key이름 변경

## 이슈 번호
- #92 