### PR TITLE
[피드백 등 목록 조회] 삭제 시 default 이모지가 삭제되어 조회가 안되는 문제 해결

### DIFF
--- a/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackEmojiRepository.java
@@ -8,5 +8,5 @@ public interface FeedbackEmojiRepository extends JpaRepository<FeedbackEmoji, Lo
 
     Optional<FeedbackEmoji> findByFeedbackIdAndUserId(long feedbackId, long userId);
 
-    void deleteAllByFeedbackId(long feedbackId);
+    void deleteAllByFeedbackIdAndUserIdIsNotNull(long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
@@ -20,5 +20,5 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
         + "from Feedback f "
         + "where f.id = :feedbackId "
         + "and (f.deletedAt is null or (f.deletedAt is not null and f.childCnt > 0)) ")
-    Optional<Feedback> findFeedbackById(@Param("feedbackId") long feedbackId);
+    Optional<Feedback> findParentFeedbackById(@Param("feedbackId") long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/reviewme/be/feedback/repository/FeedbackRepository.java
@@ -19,6 +19,6 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long>, Feedb
     @Query("select f "
         + "from Feedback f "
         + "where f.id = :feedbackId "
-        + "and (f.deletedAt is null) or (f.deletedAt is not null and f.childCnt > 0) ")
+        + "and (f.deletedAt is null or (f.deletedAt is not null and f.childCnt > 0)) ")
     Optional<Feedback> findFeedbackById(@Param("feedbackId") long feedbackId);
 }

--- a/src/main/java/reviewme/be/feedback/service/FeedbackService.java
+++ b/src/main/java/reviewme/be/feedback/service/FeedbackService.java
@@ -243,7 +243,7 @@ public class FeedbackService {
 
     private Feedback findParentFeedbackById(long feedbackId) {
 
-        return feedbackRepository.findFeedbackById(feedbackId)
+        return feedbackRepository.findParentFeedbackById(feedbackId)
             .orElseThrow(() -> new NonExistFeedbackException("존재하지 않는 피드백입니다."));
     }
 

--- a/src/main/java/reviewme/be/feedback/service/FeedbackService.java
+++ b/src/main/java/reviewme/be/feedback/service/FeedbackService.java
@@ -170,7 +170,7 @@ public class FeedbackService {
         feedback.validateUser(user);
         LocalDateTime deletedAt = LocalDateTime.now();
         feedback.softDelete(deletedAt);
-        feedbackEmojiRepository.deleteAllByFeedbackId(feedbackId);
+        feedbackEmojiRepository.deleteAllByFeedbackIdAndUserIdIsNotNull(feedbackId);
 
         if (feedback.getParentFeedback() != null) {
             feedback.getParentFeedback().minusChildCnt();

--- a/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionEmojiRepository.java
@@ -8,5 +8,5 @@ public interface QuestionEmojiRepository extends JpaRepository<QuestionEmoji, Lo
 
     Optional<QuestionEmoji> findByQuestionIdAndUserId(long questionId, long userId);
 
-    void deleteAllByQuestionId(long questionId);
+    void deleteAllByQuestionIdAndUserIdIsNotNull(long questionId);
 }

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -155,7 +155,7 @@ public class QuestionService {
         question.validateUser(user);
         LocalDateTime deletedAt = LocalDateTime.now();
         question.softDelete(deletedAt);
-        questionEmojiRepository.deleteAllByQuestionId(questionId);
+        questionEmojiRepository.deleteAllByQuestionIdAndUserIdIsNotNull(questionId);
 
         if (question.getParentQuestion() != null) {
             question.getParentQuestion().minusChildCnt();

--- a/src/main/java/reviewme/be/resume/dto/response/ResumeDetailResponse.java
+++ b/src/main/java/reviewme/be/resume/dto/response/ResumeDetailResponse.java
@@ -16,6 +16,9 @@ public class ResumeDetailResponse {
     @Schema(description = "이력서 제목", example = "네이버 신입 개발자 준비")
     private String title;
 
+    @Schema(description = "이력서 작성자 ID", example = "1")
+    private long writerId;
+
     @Schema(description = "이력서 작성자 이름", example = "aken-you")
     private String writerName;
 
@@ -29,9 +32,11 @@ public class ResumeDetailResponse {
     private int year;
 
     public static ResumeDetailResponse fromResume(Resume resume) {
+
         return ResumeDetailResponse.builder()
                 .resumeUrl(resume.getUrl())
                 .title(resume.getTitle())
+                .writerId(resume.getWriter().getId())
                 .writerName(resume.getWriter().getName())
                 .writerProfileUrl(resume.getWriter().getProfileUrl())
                 .occupation(resume.getOccupation().getOccupation())


### PR DESCRIPTION
## 개요
- 피드백과 예상 질문에 삭제되더라도 대댓글이 존재하면 조회가 가능하다.
- 피드백과 예상 질문 삭제 시 default 이모지가 삭제되어 조회할 때 문제 발생

## 작업 사항
- 피드백(예상 질문) 삭제 시 default 이모지는 삭제되지 않도록 함
- 조회 시 일부 쿼리 수정

## 이슈 번호
- #98 