### PR TITLE
[예상 질문] 예상 질문 관련 API 수정

### DIFF
--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -220,32 +220,6 @@ public class QuestionController {
             ));
     }
 
-    @Operation(summary = "예상 질문 라벨 목록 조회", description = "예상 질문 라벨 목록을 조회합니다.")
-    @GetMapping("/label")
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "예상 질문 라벨 목록 조회 성공"),
-        @ApiResponse(responseCode = "400", description = "예상 질문 라벨 목록 조회 실패")
-    })
-    public ResponseEntity<CustomResponse<LabelPageResponse>> showQuestionLabels(
-        @PathVariable long resumeId) {
-
-        List<LabelResponse> questionLabelsResponse = questionService.findQuestionLabels(resumeId)
-            .stream()
-            .map(LabelResponse::fromLabel)
-            .collect(Collectors.toList());
-
-        return ResponseEntity
-            .ok()
-            .body(new CustomResponse<>(
-                "success",
-                200,
-                "예상 질문 라벨 목록 조회에 성공했습니다.",
-                LabelPageResponse.builder()
-                    .labels(questionLabelsResponse)
-                    .build()
-            ));
-    }
-
     @Operation(summary = "예상 질문 이모지 수정", description = "예상 질문에 표시할 이모지를 수정합니다.")
     @PatchMapping("/{questionId}/emoji")
     @ApiResponses({

--- a/src/main/java/reviewme/be/question/controller/QuestionController.java
+++ b/src/main/java/reviewme/be/question/controller/QuestionController.java
@@ -149,7 +149,7 @@ public class QuestionController {
             ));
     }
 
-    @Operation(summary = "예상 질문 내용 수정", description = "예상 질문 내용을 수정합니다.")
+    @Operation(summary = "예상 질문 수정", description = "예상 질문을 수정합니다.")
     @PatchMapping("/{questionId}")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "예상 질문 수정 성공"),

--- a/src/main/java/reviewme/be/question/dto/request/UpdateQuestionContentRequest.java
+++ b/src/main/java/reviewme/be/question/dto/request/UpdateQuestionContentRequest.java
@@ -12,6 +12,9 @@ import javax.validation.constraints.NotBlank;
 @Schema(description = "예상 질문 내용 수정 요청")
 public class UpdateQuestionContentRequest {
 
+    @Schema(description = "라벨 내용", example = "react-query", required = false)
+    private String labelContent;
+
     @Schema(description = "예상 질문 수정 내용", example = "프로젝트에서 react-query말고 다른 방법은 없을까요?")
     @NotBlank(message = "예상 질문 내용은 필수 입력 값입니다.")
     private String content;

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -82,8 +82,9 @@ public class Question {
         this.childCnt--;
     }
 
-    public void updateContent(String content) {
+    public void updateContent(String labelContent, String content) {
 
+        this.labelContent = labelContent;
         this.content = content;
     }
 

--- a/src/main/java/reviewme/be/question/entity/Question.java
+++ b/src/main/java/reviewme/be/question/entity/Question.java
@@ -27,9 +27,7 @@ public class Question {
     @JoinColumn(name = "parent_id")
     private Question parentQuestion;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "label_id")
-    private Label label;
+    private String labelContent;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "resume_id")
@@ -43,12 +41,12 @@ public class Question {
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
 
-    public static Question createQuestion(User commenter, Resume resume, Label label, String content, Integer resumePage) {
+    public static Question createQuestion(User commenter, Resume resume, String labelContent, String content, Integer resumePage) {
 
         return Question.builder()
             .commenter(commenter)
             .resume(resume)
-            .label(label)
+            .labelContent(labelContent)
             .content(content)
             .resumePage(resumePage)
             .bookmarked(false)

--- a/src/main/java/reviewme/be/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/reviewme/be/question/repository/QuestionRepositoryImpl.java
@@ -2,7 +2,6 @@ package reviewme.be.question.repository;
 
 import static reviewme.be.question.entity.QQuestion.question;
 import static reviewme.be.question.entity.QQuestionEmoji.questionEmoji;
-import static reviewme.be.util.entity.QLabel.label;
 
 import com.querydsl.core.QueryResults;
 import com.querydsl.jpa.JPAExpressions;
@@ -31,7 +30,7 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             .select(new QQuestionInfo(
                 question.id,
                 question.content,
-                label.content,
+                question.labelContent,
                 question.commenter.id,
                 question.commenter.name,
                 question.commenter.profileUrl,
@@ -48,7 +47,6 @@ public class QuestionRepositoryImpl implements QuestionRepositoryCustom {
             ))
             .from(question)
             .innerJoin(question.commenter)
-            .leftJoin(question.label, label)
             .where(question.resume.id.eq(resumeId)
                 .and(question.resumePage.eq(resumePage))
                 .and(question.deletedAt.isNull()

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -41,7 +41,6 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
     private final QuestionEmojiRepository questionEmojiRepository;
     private final ResumeService resumeService;
-    private final LabelRepository labelRepository;
     private final UtilService utilService;
     private final EmojisVO emojisVO;
 
@@ -225,15 +224,6 @@ public class QuestionService {
         questionEmojiRepository.save(
             new QuestionEmoji(user, question, emoji)
         );
-    }
-
-    @Transactional(readOnly = true)
-    public List<Label> findQuestionLabels(long resumeId) {
-
-        // 이력서 존재 여부 확인
-        resumeService.findById(resumeId);
-
-        return labelRepository.findByResumeIdOrderByContentAsc(resumeId);
     }
 
     private Question findById(long questionId) {

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -51,11 +51,8 @@ public class QuestionService {
         // 이력서 존재 여부 확인
         Resume resume = resumeService.findById(resumeId);
 
-        // 예상 질문 라벨 조회 (없다면 생성)
-        Label label = verifyQuestionLabel(request, resume);
-
         Question savedQuestion = questionRepository.save(
-            Question.createQuestion(commenter, resume, label, request.getContent(),
+            Question.createQuestion(commenter, resume, request.getLabelContent(), request.getContent(),
                 request.getResumePage()));
 
         saveDefaultEmojis(savedQuestion);
@@ -237,26 +234,6 @@ public class QuestionService {
         resumeService.findById(resumeId);
 
         return labelRepository.findByResumeIdOrderByContentAsc(resumeId);
-    }
-
-    /**
-     * labelId가 있다면 해당 labelId로 label을 찾고, 이미 존재하는 labelContent라면 해당 label을 반환하고, 없다면 새로 생성
-     *
-     * @param request (Optional labelId, Optional labelContent)
-     * @param resume
-     * @return
-     */
-    private Label verifyQuestionLabel(CreateQuestionRequest request, Resume resume) {
-
-        if (request.getLabelContent() != null && !request.getLabelContent().isEmpty()) {
-
-            return labelRepository.findByResumeIdAndContent(resume.getId(),
-                    request.getLabelContent())
-                .orElseGet(
-                    () -> labelRepository.save(Label.ofCreated(resume, request.getLabelContent())));
-        }
-
-        return null;
     }
 
     private Question findById(long questionId) {

--- a/src/main/java/reviewme/be/question/service/QuestionService.java
+++ b/src/main/java/reviewme/be/question/service/QuestionService.java
@@ -169,7 +169,7 @@ public class QuestionService {
         Question question = findById(questionId);
         question.validateUser(user);
 
-        question.updateContent(request.getContent());
+        question.updateContent(request.getLabelContent(), request.getContent());
     }
 
     @Transactional

--- a/src/main/java/reviewme/be/resume/entity/Resume.java
+++ b/src/main/java/reviewme/be/resume/entity/Resume.java
@@ -37,7 +37,6 @@ public class Resume {
     private String title;
     private String url;
     private int year;
-    private int commentCnt;
     private LocalDateTime createdAt;
     private LocalDateTime deletedAt;
 
@@ -50,7 +49,6 @@ public class Resume {
             .title(uploadResumeRequest.getTitle())
             .url(fileName)
             .year(uploadResumeRequest.getYear())
-            .commentCnt(0)
             .createdAt(LocalDateTime.now())
             .build();
     }

--- a/src/main/java/reviewme/be/user/entity/User.java
+++ b/src/main/java/reviewme/be/user/entity/User.java
@@ -1,5 +1,6 @@
 package reviewme.be.user.entity;
 
+import java.time.LocalDateTime;
 import lombok.*;
 import reviewme.be.user.dto.UserGitHubProfile;
 
@@ -24,12 +25,14 @@ public class User {
     private long githubId;
     private String name;
     private String profileUrl;
+    private LocalDateTime createdAt;
 
-    public User(UserGitHubProfile userGitHubProfile) {
+    public User(UserGitHubProfile userGitHubProfile, LocalDateTime createdAt) {
 
         this.githubId = userGitHubProfile.getId();
         this.name = userGitHubProfile.getLogin();
         this.profileUrl = userGitHubProfile.getAvatarUrl();
+        this.createdAt = createdAt;
     }
 
     public void validateSameUser(User user) {

--- a/src/main/java/reviewme/be/user/entity/User.java
+++ b/src/main/java/reviewme/be/user/entity/User.java
@@ -41,6 +41,8 @@ public class User {
 
     public boolean isAnonymous() {
 
-        return this.id == 0L;
+        long anonymousUserId = 0L;
+
+        return this.id == anonymousUserId;
     }
 }

--- a/src/main/java/reviewme/be/user/service/UserService.java
+++ b/src/main/java/reviewme/be/user/service/UserService.java
@@ -1,5 +1,6 @@
 package reviewme.be.user.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,8 +33,10 @@ public class UserService {
 
         Optional<User> user = userRepository.findByGithubId(userGithubProfile.getId());
 
+        LocalDateTime createdAt = LocalDateTime.now();
+
         User loggedInUser = user.orElseGet(
-                () -> userRepository.save(new User(userGithubProfile)));
+                () -> userRepository.save(new User(userGithubProfile, createdAt)));
 
         return UserProfileResponse.fromUser(loggedInUser);
     }

--- a/src/main/java/reviewme/be/util/entity/Label.java
+++ b/src/main/java/reviewme/be/util/entity/Label.java
@@ -16,16 +16,11 @@ public class Label {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "resume_id")
-    private Resume resume;
-
     private String content;
 
-    public static Label ofCreated(Resume resume, String content) {
+    public static Label ofCreated(String content) {
 
         return Label.builder()
-            .resume(resume)
             .content(content)
             .build();
     }

--- a/src/main/java/reviewme/be/util/repository/LabelRepository.java
+++ b/src/main/java/reviewme/be/util/repository/LabelRepository.java
@@ -8,11 +8,5 @@ import java.util.Optional;
 
 public interface LabelRepository extends JpaRepository<Label, Integer> {
 
-    List<Label> findByResumeIsNull();
-
-    List<Label> findByResumeIdOrderByContentAsc(long resumeId);
-
     Optional<Label> findById(long id);
-
-    Optional<Label> findByResumeIdAndContent(long resumeId, String content);
 }

--- a/src/main/java/reviewme/be/util/vo/FeedbackLabelsVO.java
+++ b/src/main/java/reviewme/be/util/vo/FeedbackLabelsVO.java
@@ -24,7 +24,7 @@ public class FeedbackLabelsVO {
     @PostConstruct
     public void init() {
 
-        feedbackLabelList = labelRepository.findByResumeIsNull();
+        feedbackLabelList = labelRepository.findAll();
 
         feedbackLabels = feedbackLabelList.stream()
                 .collect(


### PR DESCRIPTION
## 개요
- 예상 질문 라벨 삭제, 예상 질문 별로 labelContent 관리

## 작업 사항
- 테이블 역정규화 및 데이터 마이그레이션
- 예상 질문 추가 시 labelId 삭제
- 예상 질문 라벨 목록 조회 API 삭제
- 예상 질문 수정 API labelContent를 수정할 수 있도록 함

## 이슈 번호
- #100 