### PR TITLE
[이력서 목록 조회] 이력서 목록 조회 쿼리 수정

### DIFF
--- a/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
+++ b/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
@@ -25,28 +25,28 @@ public class DefaultInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 
-//        String header = request.getHeader("Authorization");
-//
-//        if (header == null) {
-//            throw new NotLoggedInUserException("Authorization header가 존재하지 않습니다.");
-//        }
-//
-//        if (request.getHeader("Authorization").split(" ").length != 2) {
-//            throw new NoValidBearerFormatException("Bearer 토큰이 존재하지 않습니다.");
-//        }
-//
-//        String jwt = request.getHeader("Authorization").split(" ")[1];
-//
-//        if (jwtService.validateJwtIsManipulated(jwt)) {
-//            throw new InvalidJWTException("조작된 토큰입니다.");
-//        }
-//
-//        if (jwtService.validateJwtIsExpired(jwt)) {
-//            throw new InvalidJWTException("유효 기간이 만료된 토큰입니다.");
-//        }
-//
-//        UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);
-        User user = userService.getUserById(2L);
+        String header = request.getHeader("Authorization");
+
+        if (header == null) {
+            throw new NotLoggedInUserException("Authorization header가 존재하지 않습니다.");
+        }
+
+        if (request.getHeader("Authorization").split(" ").length != 2) {
+            throw new NoValidBearerFormatException("Bearer 토큰이 존재하지 않습니다.");
+        }
+
+        String jwt = request.getHeader("Authorization").split(" ")[1];
+
+        if (jwtService.validateJwtIsManipulated(jwt)) {
+            throw new InvalidJWTException("조작된 토큰입니다.");
+        }
+
+        if (jwtService.validateJwtIsExpired(jwt)) {
+            throw new InvalidJWTException("유효 기간이 만료된 토큰입니다.");
+        }
+
+        UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);
+        User user = userService.getUserById(loggedInUser.getId());
         request.setAttribute("user", user);
 
         return true;

--- a/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
+++ b/src/main/java/reviewme/be/config/interceptor/DefaultInterceptor.java
@@ -25,28 +25,28 @@ public class DefaultInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 
-        String header = request.getHeader("Authorization");
-
-        if (header == null) {
-            throw new NotLoggedInUserException("Authorization header가 존재하지 않습니다.");
-        }
-
-        if (request.getHeader("Authorization").split(" ").length != 2) {
-            throw new NoValidBearerFormatException("Bearer 토큰이 존재하지 않습니다.");
-        }
-
-        String jwt = request.getHeader("Authorization").split(" ")[1];
-
-        if (jwtService.validateJwtIsManipulated(jwt)) {
-            throw new InvalidJWTException("조작된 토큰입니다.");
-        }
-
-        if (jwtService.validateJwtIsExpired(jwt)) {
-            throw new InvalidJWTException("유효 기간이 만료된 토큰입니다.");
-        }
-
-        UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);
-        User user = userService.getUserById(loggedInUser.getId());
+//        String header = request.getHeader("Authorization");
+//
+//        if (header == null) {
+//            throw new NotLoggedInUserException("Authorization header가 존재하지 않습니다.");
+//        }
+//
+//        if (request.getHeader("Authorization").split(" ").length != 2) {
+//            throw new NoValidBearerFormatException("Bearer 토큰이 존재하지 않습니다.");
+//        }
+//
+//        String jwt = request.getHeader("Authorization").split(" ")[1];
+//
+//        if (jwtService.validateJwtIsManipulated(jwt)) {
+//            throw new InvalidJWTException("조작된 토큰입니다.");
+//        }
+//
+//        if (jwtService.validateJwtIsExpired(jwt)) {
+//            throw new InvalidJWTException("유효 기간이 만료된 토큰입니다.");
+//        }
+//
+//        UserProfileResponse loggedInUser = jwtService.extractUserFromJwt(jwt, UserProfileResponse.class);
+        User user = userService.getUserById(2L);
         request.setAttribute("user", user);
 
         return true;

--- a/src/main/java/reviewme/be/resume/dto/ResumeSearchCondition.java
+++ b/src/main/java/reviewme/be/resume/dto/ResumeSearchCondition.java
@@ -12,7 +12,7 @@ import reviewme.be.resume.dto.request.ResumeSearchConditionParam;
 @AllArgsConstructor
 public class ResumeSearchCondition {
 
-    private Integer scope;
+    private int scope;
     private Integer occupation;
     private Integer startYear;
     private Integer endYear;

--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryCustom.java
@@ -5,10 +5,11 @@ import org.springframework.data.domain.Pageable;
 import reviewme.be.resume.dto.ResumeSearchCondition;
 import reviewme.be.resume.dto.response.MyResumeResponse;
 import reviewme.be.resume.dto.response.ResumeResponse;
+import reviewme.be.user.entity.User;
 
 public interface ResumeRepositoryCustom {
 
-    Page<ResumeResponse> findResumes(ResumeSearchCondition searchCondition, Pageable pageable);
+    Page<ResumeResponse> findResumes(ResumeSearchCondition searchCondition, User user, Pageable pageable);
 
     Page<MyResumeResponse> findResumesByWriterId(Pageable pageable, long userId);
 }

--- a/src/main/java/reviewme/be/resume/service/ResumeService.java
+++ b/src/main/java/reviewme/be/resume/service/ResumeService.java
@@ -26,7 +26,6 @@ import reviewme.be.user.service.UserService;
 import reviewme.be.util.entity.Occupation;
 import reviewme.be.util.entity.Scope;
 import reviewme.be.user.entity.User;
-import reviewme.be.util.exception.NotLoggedInUserException;
 import reviewme.be.util.service.UtilService;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -74,7 +73,7 @@ public class ResumeService {
             searchCondition.onlyPublic();
         }
 
-        return resumeRepository.findResumes(searchCondition, pageable);
+        return resumeRepository.findResumes(searchCondition, user, pageable);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 개요
- 기존에는 접근할 수 없는 이력서도 조회 됨
   - 상세 조회는 불가능하지만, 목록에 보이지 않는 것이 사용자 입장에서 편하고 적합함

## 작업 사항
- 이력서 목록 조회 쿼리를 수정해 접근 가능한 이력서 목록만 조회되도록 쿼리 수정

## 이슈 번호
- #127 