### PR TITLE
[이력서 목록 조회] 이력서 목록 조회 쿼리 수정

### DIFF
--- a/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
+++ b/src/main/java/reviewme/be/resume/repository/ResumeRepositoryImpl.java
@@ -110,8 +110,9 @@ public class ResumeRepositoryImpl implements ResumeRepositoryCustom {
                 .and(resume.writer.id.in(
                     queryFactory.select(friend.followerUser.id)
                         .from(friend)
-                        .where(friend.followingUser.id.eq(user.getId()))
-                ));
+                        .where(friend.followingUser.id.eq(user.getId())
+                            .or(friend.followerUser.id.eq(user.getId()))))
+                );
 
             return publicCondition.or(friendCondition);
         }


### PR DESCRIPTION
## 개요
- 자신의 이력서 중 공개 범위가 친구에게만 공개인 이력서가 조회가 안되는 문제

## 작업 사항
- 자신의 이력서 중 공개 범위가 친구에게만 공개인 이력서도 조회되도록 로직 수정

## 이슈 번호
- #132 