### PR TITLE
[모니터링] monitoring 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 	// jwt
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 
+	// actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,3 +27,9 @@ springdoc:
       enabled: true
   cache:
     disabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, prometheus


### PR DESCRIPTION
## 개요
- 서비스 운영을 하면 서버의 상태 관리를 할 필요가 있다.
- 따라서 모니터링 환경 설정 추가

## 작업 사항

## 이슈 번호
- #129 