### PR TITLE
[이력서 목록 조회] 친구 관련 데이터가 없는 경우 자신의 친구에게만 공개 이력서가 조회 안되는 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,11 +6,6 @@ spring:
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
-  jpa:
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
 
 # Swagger springdoc-ui Configuration
 springdoc:


### PR DESCRIPTION
## 개요

## 작업 사항
- 사용자는 자신의 친구에게만 공개 이력서를 볼 수 있도록 함.
- 친구로 등록된 친구의 친구에게만 공개 이력서를 볼 수 있도록 함.

## 이슈 번호
