### PR TITLE
[업로드 파일 크기 제한] 이력서 업로드 시 파일 크기 제한 설정 추가

### DIFF
--- a/src/main/java/reviewme/be/resume/controller/ResumeController.java
+++ b/src/main/java/reviewme/be/resume/controller/ResumeController.java
@@ -38,7 +38,7 @@ public class ResumeController {
     private final ResumeService resumeService;
 
     @Operation(summary = "이력서 업로드", description = "이력서를 업로드합니다.")
-    @PostMapping
+    @PostMapping(consumes = {"multipart/form-data"})
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "이력서 업로드 성공"),
         @ApiResponse(responseCode = "400", description = "이력서 업로드 실패")

--- a/src/main/java/reviewme/be/resume/controller/ResumeExceptionHandler.java
+++ b/src/main/java/reviewme/be/resume/controller/ResumeExceptionHandler.java
@@ -3,7 +3,6 @@ package reviewme.be.resume.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import reviewme.be.custom.CustomErrorResponse;
 import reviewme.be.resume.exception.BadFileExtensionException;

--- a/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
+++ b/src/main/java/reviewme/be/util/controller/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package reviewme.be.util.controller;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -93,6 +94,7 @@ public class GlobalExceptionHandler {
                         404,
                         ex.getMessage()));
     }
+
     @ExceptionHandler(NonExistScopeException.class)
     public ResponseEntity<CustomErrorResponse> nonExistScope(NonExistScopeException ex) {
 
@@ -135,5 +137,17 @@ public class GlobalExceptionHandler {
                         "Unauthorized",
                         401,
                         ex.getMessage()));
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<CustomErrorResponse> sizeLimitExceededException(SizeLimitExceededException ex) {
+
+        return ResponseEntity
+            .badRequest()
+            .body(new CustomErrorResponse(
+                "업로드할 수 있는 pdf의 최대 크기를 초과했습니다",
+                400,
+                ex.getMessage()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,10 @@ spring:
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 # Swagger springdoc-ui Configuration
 springdoc:


### PR DESCRIPTION
## 개요
- 업로드할 이력서에 이미지가 있는 경우 1MB를 넘기기 쉬움

## 작업 사항
- 업로드 파일 크기 제한
- 제한된 파일 크기 초과 시 에러 핸들

## 이슈 번호
- #138 